### PR TITLE
Added support for importing public keys into certificate stores

### DIFF
--- a/DSCResources/MSFT_xCertificateImport/MSFT_xCertificateImport.psm1
+++ b/DSCResources/MSFT_xCertificateImport/MSFT_xCertificateImport.psm1
@@ -1,0 +1,268 @@
+#Requires -Version 4.0
+
+<#
+.SYNOPSIS
+    Validates the existence of a file at a specific path.
+
+.PARAMETER Path
+    The location of the file. Supports any path that Test-Path supports.
+
+.PARAMETER Quiet
+    Returns $false if the file does not exist. By default this function throws an exception if the file is missing.
+
+.EXAMPLE
+    Validate-CertificatePath -Path '\\server\share\Certificates\mycert.cer'
+
+.EXAMPLE
+    Validate-CertificatePath -Path 'C:\certs\my_missing.cer' -Quiet
+
+.EXAMPLE
+    'D:\CertRepo\a_cert.cer' | Validate-CertificatePath
+
+.EXAMPLE
+    Get-ChildItem D:\CertRepo\*.cer | Validate-CertificatePath
+#>
+function Validate-CertificatePath 
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline
+        )]
+        [String[]]
+        $Path ,
+
+        [Parameter()]
+        [Switch]
+        $Quiet
+    )
+
+    Process 
+    {
+        foreach($p in $Path) 
+        {
+            if ($p | Test-Path -PathType Leaf) 
+            {
+                $true
+            } 
+            elseif ($Quiet) 
+            {
+                $false
+            } 
+            else 
+            {
+                throw [System.ArgumentException]"File '$p' not found."
+            } 
+        }
+    }
+}
+
+<#
+.SYNOPSIS
+    Validates whether a given certificate is valid based on the hash algoritms available on the system.
+
+.PARAMETER Thumbprint
+    One or more thumbprints to validate.
+
+.PARAMETER Quiet
+    Returns $false if the thumbprint is not valid. By default this function throws an exception if validation fails.
+
+.EXAMPLE
+    Validate-Thumbprint fd94e3a5a7991cb6ed3cd5dd01045edf7e2284de
+
+.EXAMPLE
+    Validate-Thumbprint fd94e3a5a7991cb6ed3cd5dd01045edf7e2284de,0000e3a5a7991cb6ed3cd5dd01045edf7e220000 -Quiet
+
+.EXAMPLE
+    gci Cert:\LocalMachine -Recurse | ? { $_.Thumbprint } | select -exp Thumbprint | Validate-Thumbprint -Verbose
+#>
+function Validate-Thumbprint 
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline
+        )]
+        [ValidateNotNullOrEmpty()]
+        [String[]]
+        $Thumbprint ,
+
+        [Parameter()]
+        [Switch]
+        $Quiet
+    )
+
+    Begin 
+    {
+        $validHashes = [System.AppDomain]::CurrentDomain.GetAssemblies().GetTypes() | Where-Object {
+            $_.BaseType.BaseType -eq [System.Security.Cryptography.HashAlgorithm] -and
+            $_.Name -cmatch 'Managed$'
+        } | ForEach-Object {
+            New-Object PSObject -Property @{
+                Hash = $_.BaseType.Name
+                BitSize = (New-Object $_).HashSize
+            } | Add-Member -MemberType ScriptProperty -Name HexLength -Value { 
+                $this.BitSize / 4 
+            } -PassThru
+        }
+    }
+
+    Process 
+    {
+        foreach($hash in $Thumbprint) 
+        {
+            $isValid = $false
+
+            foreach($algorithm in $validHashes)
+            {
+                if ($hash -cmatch "^[a-fA-F0-9]{$($algorithm.HexLength)}$")
+                {
+                    Write-Verbose -Message "'$hash' is a valid $($algorithm.Hash) hash."
+                    $isValid = $true
+                }
+            }
+            
+            if ($Quiet -or $isValid)
+            {
+                $isValid
+            }
+            else
+            {
+                throw [System.ArgumentException]"'$hash' is not a valid hash."
+            }
+        }
+    }
+}
+
+function Get-TargetResource 
+{
+    [CmdletBinding()]
+    [OutputType([Hashtable])]
+    param(
+        [Parameter(
+            Mandatory
+        )]
+        [ValidateScript( {
+            $_ | Validate-Thumbprint
+        } )]
+        [String]
+        $Thumbprint ,
+
+        [Parameter(
+            Mandatory
+        )]
+        [ValidateScript( {
+            $_ | Validate-CertificatePath
+        } )]
+        [String]
+        $Path ,
+
+        [Parameter()]
+        [ValidateSet(
+             'LocalMachine'
+        )]
+        [String]
+        $Location = 'LocalMachine' ,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $Store = 'My'
+    )
+
+    @{
+        Thumbprint = $Thumbprint
+        Path = $Path
+    }
+}
+
+function Test-TargetResource 
+{
+    [CmdletBinding()]
+    [OutputType([Bool])]
+    param(
+        [Parameter(
+            Mandatory
+        )]
+        [ValidateScript( {
+            $_ | Validate-Thumbprint
+        } )]
+        [String]
+        $Thumbprint ,
+
+        [Parameter(
+            Mandatory
+        )]
+        [ValidateScript( {
+            $_ | Validate-CertificatePath
+        } )]
+        [String]
+        $Path ,
+
+        [Parameter()]
+        [ValidateSet(
+             'LocalMachine'
+        )]
+        [String]
+        $Location = 'LocalMachine' ,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $Store = 'My'
+    )
+
+    [Bool](
+        'Cert:' | 
+        Join-Path -ChildPath $Location | 
+        Join-Path -ChildPath $Store | 
+        Get-ChildItem | 
+        Where-Object { $_.Thumbprint -ieq $Thumbprint }
+     )
+}
+
+function Set-TargetResource 
+{
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(
+            Mandatory
+        )]
+        [ValidateScript( {
+            $_ | Validate-Thumbprint
+        } )]
+        [String]
+        $Thumbprint ,
+
+        [Parameter(
+            Mandatory
+        )]
+        [ValidateScript( {
+            $_ | Validate-CertificatePath
+        } )]
+        [String]
+        $Path ,
+
+        [Parameter()]
+        [ValidateSet(
+             'LocalMachine'
+        )]
+        [String]
+        $Location = 'LocalMachine' ,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $Store = 'My'
+    )
+
+    $certPath = 'Cert:' | Join-Path -ChildPath $Location | Join-Path -ChildPath $Store
+    if ($PSCmdlet.ShouldProcess("Importing certificate '$Path' into '$certPath'")) 
+    {
+        Import-Certificate -CertStoreLocation $certPath -FilePath $Path
+    }
+}
+
+Export-ModuleMember *-TargetResource

--- a/DSCResources/MSFT_xCertificateImport/MSFT_xCertificateImport.schema.mof
+++ b/DSCResources/MSFT_xCertificateImport/MSFT_xCertificateImport.schema.mof
@@ -1,0 +1,8 @@
+[ClassVersion("1.0"), FriendlyName("xCertificateImport")]
+class MSFT_xCertificateImport : OMI_BaseResource
+{
+[Key] string Thumbprint;
+[Key] string Path;
+[write,ValueMap{"LocalMachine"},Values{"LocalMachine"}] string Location;
+[write] string Store;
+};

--- a/Examples/Sample_xCertificateImport_MinimalUsage.ps1
+++ b/Examples/Sample_xCertificateImport_MinimalUsage.ps1
@@ -1,0 +1,14 @@
+Configuration MyNode
+{
+    Import-DscResource -ModuleName xCertificate
+
+    Node $AllNodes.NodeName
+    {
+        xCertificateImport MyTrustedRoot
+        {
+            Thumbprint = 'c81b94933420221a7ac004a90242d8b1d3e5070d'
+            Store = "Root"
+            Path = '\\Server\Share\Certificates\MyTrustedRoot.cer'
+        }
+    }
+}

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -40,9 +40,18 @@ Resources
 - **Exportable**: Defaults to `$false`. Determines whether the private key is exportable from the machine after you import it.
 - **Credential**: A `[PSCredential]` object that is used to decrypt the PFX file. Only the password is used, so any user name is valid.
 
+**xCertificate** resource has following properties
+
+- **Thumbprint**: The thumbprint (unique identifier) of the certificate you're importing.
+- **Path**: The path to the PFX file you want to import.
+- **Location**: Currently the only valid value here is `LocalMachine`.
+- **Store**: Defaults to `My` (the personal store) but can be any store that is valid on the machine (for example, `WebHosting`).
 
 Versions
 --------
+
+### Unreleased
+* Added new resource: xCertificateImport
 
 ### 1.1.0.0
 * Added new resource: xPfxImport
@@ -67,9 +76,9 @@ Examples
 configuration SSL
 {
 param (
-    [Parameter(Mandatory=$true)] 
-    [ValidateNotNullorEmpty()] 
-    [PsCredential] $Credential 
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullorEmpty()]
+    [PsCredential] $Credential
     )
 Import-DscResource -ModuleName xCertificate
 Node 'localhost'
@@ -77,7 +86,7 @@ Node 'localhost'
 	xCertReq SSLCert
 
 	{
-		
+
 		CARootName                = 'test-dc01-ca'
 
 		CAServerFQDN              = 'dc01.test.pha'
@@ -129,5 +138,18 @@ xPfxImport CompanyCert
     Store = 'WebHosting'
     Credential = $PfxPassword
     DependsOn = '[WindowsFeature]IIS'
+}
+```
+
+## xCertificateImport
+
+**Example 1**: Import public key certificate into Trusted Root store
+
+```powershell
+xCertificateImport MyTrustedRoot
+{
+    Thumbprint = 'c81b94933420221a7ac004a90242d8b1d3e5070d'
+    Store = "Root"
+    Path = '\\Server\Share\Certificates\MyTrustedRoot.cer'
 }
 ```

--- a/Tests/MSFT_xCertificateImport.tests.ps1
+++ b/Tests/MSFT_xCertificateImport.tests.ps1
@@ -1,0 +1,152 @@
+<#
+.Summary
+    Tests for xCertificateImport
+#>
+
+
+$moduleName = ($PSCommandPath | Split-Path -Leaf) -replace '\..*$',''
+Import-Module ($PSScriptRoot | Split-Path -Parent | Join-Path -ChildPath DSCResources | Join-Path -ChildPath $moduleName | Join-Path -ChildPath "$moduleName.psm1") -DisableNameChecking -Force
+
+InModuleScope $moduleName {
+    $invalidThumbprint = 'Zebra'
+    $validThumbprint = (
+        [System.AppDomain]::CurrentDomain.GetAssemblies().GetTypes() | Where-Object {
+            $_.BaseType.BaseType -eq [System.Security.Cryptography.HashAlgorithm] -and
+            $_.Name -cmatch 'Managed$'
+        } | Select-Object -First 1 | ForEach-Object { 
+            (New-Object $_).ComputeHash([String]::Empty) | ForEach-Object {
+                '{0:x2}' -f $_
+            }
+        }
+    ) -join ''
+
+    $testFile = 'test.cer'
+
+    $invalidPath = 'TestDrive:'
+    $validPath = "TestDrive:\$testFile"
+    
+    Describe 'Validate-CertificatePath' {
+
+        $null | Set-Content -Path $validPath
+
+        Context 'a single existing file by parameter' {
+            $result = Validate-CertificatePath -Path $validPath
+            It 'should return true' {
+                ($result -is [bool]) | Should Be $true
+                $result | Should Be $true
+            }
+        }
+        Context 'a single missing file by parameter' {
+            It 'should throw an exception' {
+                # directories are not valid
+                { Validate-CertificatePath -Path $invalidPath } | Should Throw
+            }
+        }
+        Context 'a single missing file by parameter with -Quiet' {
+            $result = Validate-CertificatePath -Path $invalidPath -Quiet
+            It 'should return false' {
+                ($result -is [bool]) | Should Be $true
+                $result | Should Be $false
+            }
+        }
+        Context 'a single existing file by pipeline' {
+            $result = $validPath | Validate-CertificatePath
+            It 'should return true' {
+                ($result -is [bool]) | Should Be $true
+                $result | Should Be $true
+            }
+        }
+        Context 'a single missing file by pipeline' {
+            It 'should throw an exception' {
+                # directories are not valid
+                { $invalidPath | Validate-CertificatePath } | Should Throw
+            }
+        }
+        Context 'a single missing file by pipeline with -Quiet' {
+            $result =  $invalidPath | Validate-CertificatePath -Quiet
+            It 'should return false' {
+                ($result -is [bool]) | Should Be $true
+                $result | Should Be $false
+            }
+        }
+    }
+    Describe 'Validate-Thumbprint' {
+
+        Context 'a single valid thumbrpint by parameter' {
+            $result = Validate-Thumbprint -Thumbprint $validThumbprint
+            It 'should return true' {
+                ($result -is [bool]) | Should Be $true
+                $result | Should Be $true
+            }
+        }
+        Context 'a single invalid thumbprint by parameter' {
+            It 'should throw an exception' {
+                # directories are not valid
+                { Validate-Thumbprint -Thumbprint $invalidThumbprint } | Should Throw
+            }
+        }
+        Context 'a single invalid thumbprint by parameter with -Quiet' {
+            $result = Validate-Thumbprint $invalidThumbprint -Quiet
+            It 'should return false' {
+                ($result -is [bool]) | Should Be $true
+                $result | Should Be $false
+            }
+        }
+        Context 'a single valid thumbprint by pipeline' {
+            $result = $validThumbprint | Validate-Thumbprint
+            It 'should return true' {
+                ($result -is [bool]) | Should Be $true
+                $result | Should Be $true
+            }
+        }
+        Context 'a single invalid thumborint by pipeline' {
+            It 'should throw an exception' {
+                # directories are not valid
+                { $invalidThumbprint | Validate-Thumbprint } | Should Throw
+            }
+        }
+        Context 'a single invalid thumbprint by pipeline with -Quiet' {
+            $result =  $invalidThumbprint | Validate-Thumbprint -Quiet
+            It 'should return false' {
+                ($result -is [bool]) | Should Be $true
+                $result | Should Be $false
+            }
+        }
+    }
+    Describe 'Get-TargetResource' {
+        $null | Set-Content -Path $validPath
+
+        $result = Get-TargetResource -Thumbprint $validThumbprint -Path $validPath
+        It 'should return a hashtable' {
+            ($result -is [hashtable]) | Should Be $true
+        }
+        It 'should contain the input values' {
+            $result.Thumbprint | Should BeExactly $validThumbprint
+            $result.Path | Should BeExactly $validPath
+        }
+    }
+    Describe 'Test-TargetResource' {
+        $null | Set-Content -Path $validPath
+
+        It 'should return a bool' {
+            ((Test-TargetResource -Thumbprint $validThumbprint -Path $validPath) -is [bool]) | Should Be $true
+        }
+    }
+    Describe 'Set-TargetResource' {
+        $null | Set-Content -Path $validPath
+        
+        Mock Import-Certificate {} -Verifiable
+
+        Set-TargetResource -Thumbprint $validThumbprint -Path $validPath -Store "My" -Location LocalMachine
+        
+        It 'calls Import-Certificate' {
+            Assert-VerifiableMocks
+        }
+        It 'uses the parameters supplied' {
+            Assert-MockCalled Import-Certificate -Exactly -Times 1 -ParameterFilter {
+                $CertStoreLocation -eq "Cert:\LocalMachine\My" -and
+                $FilePath -eq $validPath
+            }
+        }
+    }
+}


### PR DESCRIPTION
I implemented an additional resource called xCertificateImport. This resource is basically a copy of the xPfxImport-resource, but uses the Import-Certificate command instead of Import-PfxCertificate. This allows users to import public keys into the certificate store, e.g. when they need to add a trusted root certificate.

This closes #15.