### PR TITLE
Replace $TestEnvironment.WorkingFolder with $TestDrive

### DIFF
--- a/Tests/Integration/MSFT_xCertReq.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xCertReq.Integration.Tests.ps1
@@ -62,9 +62,9 @@ try
                 }
 
                 & "$($script:DSCResourceName)_Config" `
-                    -OutputPath $TestEnvironment.WorkingFolder `
+                    -OutputPath $TestDrive `
                     -ConfigurationData $ConfigData
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 

--- a/Tests/Integration/MSFT_xCertificateImport.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xCertificateImport.Integration.Tests.ps1
@@ -47,10 +47,10 @@ try
         It 'Should compile without throwing' {
             {
                 & "$($script:DSCResourceName)_Add_Config" `
-                    -OutputPath $TestEnvironment.WorkingFolder `
+                    -OutputPath $TestDrive `
                     -Path $CertificatePath `
                     -Thumbprint $Certificate.Thumbprint
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
@@ -79,10 +79,10 @@ try
         It 'Should compile without throwing' {
             {
                 & "$($script:DSCResourceName)_Remove_Config" `
-                    -OutputPath $TestEnvironment.WorkingFolder `
+                    -OutputPath $TestDrive `
                     -Path $CertificatePath `
                     -Thumbprint $Certificate.Thumbprint
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 

--- a/Tests/Integration/MSFT_xPfxImport.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xPfxImport.Integration.Tests.ps1
@@ -61,12 +61,12 @@ try
                         )
                     }
                 & "$($script:DSCResourceName)_Add_Config" `
-                    -OutputPath $TestEnvironment.WorkingFolder `
+                    -OutputPath $TestDrive `
                     -ConfigurationData $configData `
                     -Path $CertificatePath `
                     -Thumbprint $Certificate.Thumbprint `
                     -Credential $testCredential
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
@@ -95,10 +95,10 @@ try
         It 'Should compile without throwing' {
             {
                 & "$($script:DSCResourceName)_Remove_Config" `
-                    -OutputPath $TestEnvironment.WorkingFolder `
+                    -OutputPath $TestDrive `
                     -Path $CertificatePath `
                     -Thumbprint $Certificate.Thumbprint
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 


### PR DESCRIPTION
Per PowerShell/DscResource.Tests#79 Install-ModuleFromPowerShellGallery from TestHelper.psm1 has been modified and 'WorkingFolder' has been removed from the test environment.

This PR fixes problems in this repo brought on by those changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcertificate/36)
<!-- Reviewable:end -->
