### PR TITLE
Get xCertificateImport and xPfxImport working on windows Server 2008 R2

### DIFF
--- a/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
+++ b/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
@@ -372,7 +372,7 @@ function Test-CommandExists
     return ($null -ne $command)
 }
 
-if (-not (Test-CommandExists -command 'Import-Certificate'))
+if (-not (Test-CommandExists -Name 'Import-Certificate'))
 {
     Write-Verbose -Message "Loading Import-Certificate Function"
 
@@ -397,6 +397,7 @@ if (-not (Test-CommandExists -command 'Import-Certificate'))
             [System.String]
             $CertStoreLocation
         )
+
         $Location = Split-Path -Path (Split-Path -Path $CertStoreLocation -Parent) -Leaf
         $Store = Split-Path -Path $CertStoreLocation -Leaf
         
@@ -410,7 +411,7 @@ if (-not (Test-CommandExists -command 'Import-Certificate'))
     }
 }
 
-if (-not (Test-CommandExists -command 'Import-PfxCertificate'))
+if (-not (Test-CommandExists -Name 'Import-PfxCertificate'))
 {
     Write-Verbose -Message "Loading Import-PfxCertificate Function"
   <#
@@ -450,28 +451,28 @@ if (-not (Test-CommandExists -command 'Import-PfxCertificate'))
         $Location = Split-Path -Path (Split-Path -Path $CertStoreLocation -Parent) -Leaf
         $Store = Split-Path -Path $CertStoreLocation -Leaf
         
-         $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
-         [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
+        $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
+        [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
          
-         $Flags = [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet
+        $Flags = [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet
    
-         if ($Exportable)
-         {
-             $Flags = $Flags -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
+        if ($Exportable)
+        {
+            $Flags = $Flags -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportabl
+        }
 
-         }
-         if ($Password)
-         {
-            $cert.import($FilePath, $Password, $Flags)
-         }
-         else 
-         {
-             $cert.Import($FilePath, $Flags)
-         }
-         
-         $certStore = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Store -ArgumentList $Store, $Location
-         $certStore.Open('MaxAllowed')
-         $certStore.Add($cert)
-         $certStore.Close()
+        if ($Password)
+        {
+           $cert.import($FilePath, $Password, $Flags)
+        }
+        else 
+        {
+            $cert.Import($FilePath, $Flags)
+        }
+        
+        $certStore = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Store -ArgumentList $Store, $Location
+        $certStore.Open('MaxAllowed')
+        $certStore.Add($cert)
+        $certStore.Close()
     }
 } 

--- a/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
+++ b/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
@@ -445,11 +445,11 @@ if(-not (Test-CommandExists -command "Import-PfxCertificate"))
          $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
          [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
          
-         $Flags = [Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet
+         $Flags = [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet
    
          if($Exportable)
          {
-             $Flags = $Flags -bor [Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
+             $Flags = $Flags -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
 
          }
          if($Password)

--- a/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
+++ b/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
@@ -402,7 +402,7 @@ if (-not (Test-CommandExists -Name 'Import-Certificate'))
         $Store = Split-Path -Path $CertStoreLocation -Leaf
         
         $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
-        $cert.import($FilePath)
+        $cert.Import($FilePath)
 
         $certStore = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Store -ArgumentList $Store, $Location
         $certStore.Open('MaxAllowed')
@@ -463,7 +463,7 @@ if (-not (Test-CommandExists -Name 'Import-PfxCertificate'))
 
         if ($Password)
         {
-           $cert.import($FilePath, $Password, $Flags)
+           $cert.Import($FilePath, $Password, $Flags)
         }
         else 
         {

--- a/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
+++ b/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
@@ -372,7 +372,7 @@ function Test-CommandExists
     return ($null -ne $command)
 }
 
-if(-not (Test-CommandExists -command 'Import-Certificate'))
+if (-not (Test-CommandExists -command 'Import-Certificate'))
 {
     Write-Verbose -Message "Loading Import-Certificate Function"
 
@@ -410,7 +410,7 @@ if(-not (Test-CommandExists -command 'Import-Certificate'))
     }
 }
 
-if(-not (Test-CommandExists -command 'Import-PfxCertificate'))
+if (-not (Test-CommandExists -command 'Import-PfxCertificate'))
 {
     Write-Verbose -Message "Loading Import-PfxCertificate Function"
   <#
@@ -455,12 +455,12 @@ if(-not (Test-CommandExists -command 'Import-PfxCertificate'))
          
          $Flags = [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet
    
-         if($Exportable)
+         if ($Exportable)
          {
              $Flags = $Flags -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
 
          }
-         if($Password)
+         if ($Password)
          {
             $cert.import($FilePath, $Password, $Flags)
          }

--- a/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
+++ b/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
@@ -400,10 +400,10 @@ if(-not (Test-CommandExists -command 'Import-Certificate'))
         $Location = Split-Path -Path (Split-Path -Path $CertStoreLocation -Parent) -Leaf
         $Store = Split-Path -Path $CertStoreLocation -Leaf
         
-        $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
+        $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
         $cert.import($FilePath)
 
-        $certStore = New-Object System.Security.Cryptography.X509Certificates.X509Store($Store, $Location)
+        $certStore = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Store -ArgumentList $Store, $Location
         $certStore.Open('MaxAllowed')
         $certStore.Add($cert)
         $certStore.Close()
@@ -450,7 +450,7 @@ if(-not (Test-CommandExists -command 'Import-PfxCertificate'))
         $Location = Split-Path -Path (Split-Path -Path $CertStoreLocation -Parent) -Leaf
         $Store = Split-Path -Path $CertStoreLocation -Leaf
         
-         $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
+         $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
          [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
          
          $Flags = [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet
@@ -469,7 +469,7 @@ if(-not (Test-CommandExists -command 'Import-PfxCertificate'))
              $cert.Import($FilePath, $Flags)
          }
          
-         $certStore = New-Object System.Security.Cryptography.X509Certificates.X509Store($Store, $Location)
+         $certStore = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Store -ArgumentList $Store, $Location
          $certStore.Open('MaxAllowed')
          $certStore.Add($cert)
          $certStore.Close()

--- a/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
+++ b/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
@@ -372,21 +372,21 @@ function Test-CommandExists
     return ($null -ne $command)
 }
 
-if(-not (Test-CommandExists -command "Import-Certificate"))
+if(-not (Test-CommandExists -command 'Import-Certificate'))
 {
     Write-Verbose -Message "Loading Import-Certificate Function"
 
 <#
     .SYNOPSIS
-     This function imports a 509 public key certificate to the specific Store.
+      This function imports a 509 public key certificate to the specific Store.
 
     .PARAMETER FilePath
-    The path to the certificate file to import.
+      The path to the certificate file to import.
 
     .PARAMETER CertStoreLocation
-     The Certificate Store and Location Path to import the certificate to.
-
+      The Certificate Store and Location Path to import the certificate to.
 #>
+  
     function Import-Certificate {
         param
         (
@@ -404,32 +404,32 @@ if(-not (Test-CommandExists -command "Import-Certificate"))
         $cert.import($FilePath)
 
         $certStore = New-Object System.Security.Cryptography.X509Certificates.X509Store($Store, $Location)
-        $certStore.Open("MaxAllowed")
+        $certStore.Open('MaxAllowed')
         $certStore.Add($cert)
         $certStore.Close()
     }
 }
 
-if(-not (Test-CommandExists -command "Import-PfxCertificate"))
+if(-not (Test-CommandExists -command 'Import-PfxCertificate'))
 {
     Write-Verbose -Message "Loading Import-PfxCertificate Function"
   <#
     .SYNOPSIS
-     This function imports a Pfx publiic - private certificate to the specific Certificate Store Location.
+      This function imports a Pfx publiic - private certificate to the specific Certificate Store Location.
 
     .PARAMETER FilePath
-    The path to the certificate file to import.
+      The path to the certificate file to import.
 
     .PARAMETER CertStoreLocation
-     The Certificate Store and Location Path to import the certificate to.
+      The Certificate Store and Location Path to import the certificate to.
 
     .PARAMETER Exportable
-     The paremter controls if certificate will be able to export the private key.
+      The paremter controls if certificate will be able to export the private key.
 
     .PARAMETER Password
-     The password that the Certificate located at the FilePath needs to be imported.
-
+      The password that the Certificate located at the FilePath needs to be imported.
   #> 
+
     function Import-PfxCertificate {
         param
         (
@@ -470,7 +470,7 @@ if(-not (Test-CommandExists -command "Import-PfxCertificate"))
          }
          
          $certStore = New-Object System.Security.Cryptography.X509Certificates.X509Store($Store, $Location)
-         $certStore.Open("MaxAllowed")
+         $certStore.Open('MaxAllowed')
          $certStore.Add($cert)
          $certStore.Close()
     }

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -76,6 +76,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### Unreleased
 
+- Fixed issue where xCertificate is not working when the PKI Module is not available. See [issue](https://github.com/PowerShell/xCertificate/issues/46)
 - Fixed issue where xCertReq does not process requested certificate when credentials parameter set and PSDscRunAsCredential not passed. See [issue](https://github.com/PowerShell/xCertificate/issues/49)
 
 ### 2.4.0.0

--- a/Tests/Unit/CertificateDsc.Common.Tests.ps1
+++ b/Tests/Unit/CertificateDsc.Common.Tests.ps1
@@ -9,6 +9,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
     & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
+$global:modulePath = (Join-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'Modules' -ChildPath $script:ModuleName)) -ChildPath "$script:ModuleName.psm1")
+
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 Import-Module -Name (Join-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'Modules' -ChildPath $script:ModuleName)) -ChildPath "$script:ModuleName.psm1") -Force
 Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
@@ -608,6 +610,9 @@ try
                         Source      = "PKI"
                     }
                 }
+                
+                Import-Module -Name $global:modulePath -Force
+
                 It 'should return true' {
                     (Test-CommandExists -command "Import-Certificate") | Should Be $true
                     (Test-CommandExists -command "Import-PfxCertificate") | Should Be $true
@@ -623,6 +628,8 @@ try
                 Mock -CommandName "Get-Command" -ParameterFilter { $Name -eq "Import-PfxCertificate" } -MockWith { 
                     throw "The term 'Import-PfxCertificate' is not recognized as the name of a cmdlet, function..."
                 }
+                
+                Import-Module -Name $global:modulePath -Force
 
                 It 'should return false' {
                     (Test-CommandExists -command "Import-Certificate") | Should Be $false

--- a/Tests/Unit/CertificateDsc.Common.Tests.ps1
+++ b/Tests/Unit/CertificateDsc.Common.Tests.ps1
@@ -610,9 +610,7 @@ try
                         Source      = "PKI"
                     }
                 }
-                
-                Import-Module -Name $global:modulePath -Force
-
+               
                 It 'should return true' {
                     (Test-CommandExists -command "Import-Certificate") | Should Be $true
                     (Test-CommandExists -command "Import-PfxCertificate") | Should Be $true
@@ -628,12 +626,19 @@ try
                 Mock -CommandName "Get-Command" -ParameterFilter { $Name -eq "Import-PfxCertificate" } -MockWith { 
                     throw "The term 'Import-PfxCertificate' is not recognized as the name of a cmdlet, function..."
                 }
-                
-                Import-Module -Name $global:modulePath -Force
-
-                It 'should return false' {
+               
+                It 'import-certificate should return false' {
+                   
                     (Test-CommandExists -command "Import-Certificate") | Should Be $false
+                }   
+                It 'should call relevant mocks' {
+                    Assert-MockCalled -CommandName Get-Command -Times 1
+                }
+                It 'import-pfxcertificate should return false' {
                     (Test-CommandExists -command "Import-PfxCertificate") | Should Be $false
+                }
+                It 'should call relevant mocks' {
+                              Assert-MockCalled -CommandName Get-Command -Times 1
                 }
             }
         }

--- a/Tests/Unit/CertificateDsc.Common.Tests.ps1
+++ b/Tests/Unit/CertificateDsc.Common.Tests.ps1
@@ -587,6 +587,49 @@ try
                 }
             }
         }
+
+        Describe "$DSCResourceName\Test-CommandExists" {
+             
+            Context 'Import-Certificate Cmdlet is available' {   
+                Mock -CommandName "Get-Command" -ParameterFilter { $Name -eq "Import-Certificate"} -MockWith { 
+                    return @{
+                        CommandType = [System.Management.Automation.CommandTypes]::Cmdlet
+                        Name        = "Import-Certificate"
+                        Version     = "1.0.0.0"
+                        Source      = "PKI"
+                    }
+                }
+                
+                Mock -CommandName "Get-Command" -ParameterFilter { $Name -eq "Import-PfxCertificate"} -MockWith { 
+                       return @{
+                        CommandType = [System.Management.Automation.CommandTypes]::Cmdlet
+                        Name        = "Import-PfxCertificate"
+                        Version     = "1.0.0.0"
+                        Source      = "PKI"
+                    }
+                }
+                It 'should return true' {
+                    (Test-CommandExists -command "Import-Certificate") | Should Be $true
+                    (Test-CommandExists -command "Import-PfxCertificate") | Should Be $true
+                }
+            }
+
+
+            Context "Import-Certificate Cmdlet is not available" {
+                Mock -CommandName "Get-Command" -ParameterFilter { $Name -eq "Import-Certificate" } -MockWith { 
+                    throw "The term 'Import-Certificate' is not recognized as the name of a cmdlet, function..."
+                }
+                
+                Mock -CommandName "Get-Command" -ParameterFilter { $Name -eq "Import-PfxCertificate" } -MockWith { 
+                    throw "The term 'Import-PfxCertificate' is not recognized as the name of a cmdlet, function..."
+                }
+
+                It 'should return false' {
+                    (Test-CommandExists -command "Import-Certificate") | Should Be $false
+                    (Test-CommandExists -command "Import-PfxCertificate") | Should Be $false
+                }
+            }
+        }
     }
 }
 finally


### PR DESCRIPTION
PR will "replace" the Import-Certificate and Import-PfxCertificate functions that are not available, by creating functional equivalent functions so no code in the actual resources need change. #46

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcertificate/55)
<!-- Reviewable:end -->
