### PR TITLE
PR to fix issue 61 for DNS SANs

### DIFF
--- a/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
+++ b/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
@@ -765,7 +765,7 @@ function Test-TargetResource
 			$CorrectDNSString = ($CorrectDNS | Sort-Object | Get-Unique) -join ','
 			
 			# Find out what SANs are on the current cert
-			$CurrentSanList = ($cert.Extensions | Where {$_.oid.FriendlyName -match 'Subject Alternative Name'}).Format(1).split("`n")
+			$CurrentSanList = ($cert.Extensions | Where {$_.oid.FriendlyName -match 'Subject Alternative Name'}).Format(1).split("`n").TrimEnd()
 			$CurrentDNS = @()
 			foreach ($San in $CurrentSanList) {
 				if ($San -like 'dns*') {

--- a/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
+++ b/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
@@ -820,7 +820,7 @@ function Test-TargetResource
             
             # Find out what SANs are on the current cert
             if ($cert.Extensions.Count -gt 0) {
-                $currentSanList = ($cert.Extensions | Where {$_.oid.FriendlyName -match 'Subject Alternative Name'}).Format(1).split("`n").TrimEnd()
+                $currentSanList = ($cert.Extensions | Where-Object {$_.oid.FriendlyName -match 'Subject Alternative Name'}).Format(1).split("`n").TrimEnd()
                 $currentDNS = @()
                 foreach ($san in $currentSanList) {
                     if ($san -like 'dns*') {

--- a/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
+++ b/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
@@ -753,31 +753,31 @@ function Test-TargetResource
 
         if ($PSBoundParameters.ContainsKey('SubjectAltName')) {
             # Split the desired SANs into an array
-            $SanList = $SubjectAltName.Split('&')
-            $CorrectDNS = @()
-            foreach ($San in $SanList) {
-                if ($San -like 'dns*') {
+            $sanList = $SubjectAltName.Split('&')
+            $correctDNS = @()
+            foreach ($san in $sanList) {
+                if ($san -like 'dns*') {
                     # This SAN is a DNS name
-                    $CorrectDNS += $San.split('=')[1]
+                    $correctDNS += $san.split('=')[1]
                 }
             }
             # Convert array to string (makes comparison easy)
-            $CorrectDNSString = ($CorrectDNS | Sort-Object | Get-Unique) -join ','
+            $correctDNSString = ($correctDNS | Sort-Object | Get-Unique) -join ','
             
             # Find out what SANs are on the current cert
-            $CurrentSanList = ($cert.Extensions | Where {$_.oid.FriendlyName -match 'Subject Alternative Name'}).Format(1).split("`n").TrimEnd()
-            $CurrentDNS = @()
-            foreach ($San in $CurrentSanList) {
-                if ($San -like 'dns*') {
+            $currentSanList = ($cert.Extensions | Where {$_.oid.FriendlyName -match 'Subject Alternative Name'}).Format(1).split("`n").TrimEnd()
+            $currentDNS = @()
+            foreach ($san in $currentSanList) {
+                if ($san -like 'dns*') {
                     # This SAN is a DNS name
-                    $CurrentDNS += $San.split('=')[1]
+                    $currentDNS += $san.split('=')[1]
                 }
             }
             # Convert array to string (makes comparison easy)
-            $CurrentDNSString = ($CurrentDNS | Sort-Object | Get-Unique) -join ','
+            $currentDNSString = ($currentDNS | Sort-Object | Get-Unique) -join ','
             
             # Do the cert's DNS SANs and the desired DNS SANs match?
-            if ($CurrentDNSString -ne $CorrectDNSString) {
+            if ($currentDNSString -ne $correctDNSString) {
                 return $false
             }
         }

--- a/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
+++ b/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
@@ -751,6 +751,37 @@ function Test-TargetResource
             } # if
         } # if
 
+		if ($PSBoundParameters.ContainsKey('SubjectAltName')) {
+			# Split the desired SANs into an array
+			$SanList = $SubjectAltName.Split('&')
+			$CorrectDNS = @()
+			foreach ($San in $SanList) {
+				if ($San -like 'dns*') {
+					# This SAN is a DNS name
+					$CorrectDNS += $San.split('=')[1]
+				}
+			}
+			# Convert array to string (makes comparison easy)
+			$CorrectDNSString = ($CorrectDNS | Sort-Object | Get-Unique) -join ','
+			
+			# Find out what SANs are on the current cert
+			$CurrentSanList = ($cert.Extensions | Where {$_.oid.FriendlyName -match 'Subject Alternative Name'}).Format(1)
+			$CurrentDNS = @()
+			foreach ($San in $CurrentSanList) {
+				if ($San -like 'dns*') {
+					# This SAN is a DNS name
+					$CurrentDNS += $San.split('=')[1]
+				}
+			}
+			# Convert array to string (makes comparison easy)
+			$CurrentDNSString = ($CurrentDNS | Sort-Object | Get-Unique) -join ','
+			
+			# Do the cert's DNS SANs and the desired DNS SANs match?
+			if ($CurrentDNS -ne $CorrectDNS) {
+				return $false
+			}
+		}
+
         # The certificate was found and is OK - so no change required.
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "

--- a/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
+++ b/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
@@ -765,7 +765,7 @@ function Test-TargetResource
 			$CorrectDNSString = ($CorrectDNS | Sort-Object | Get-Unique) -join ','
 			
 			# Find out what SANs are on the current cert
-			$CurrentSanList = ($cert.Extensions | Where {$_.oid.FriendlyName -match 'Subject Alternative Name'}).Format(1)
+			$CurrentSanList = ($cert.Extensions | Where {$_.oid.FriendlyName -match 'Subject Alternative Name'}).Format(1).split("`n")
 			$CurrentDNS = @()
 			foreach ($San in $CurrentSanList) {
 				if ($San -like 'dns*') {

--- a/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
+++ b/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
@@ -761,8 +761,6 @@ function Test-TargetResource
                     $correctDNS += $san.split('=')[1]
                 }
             }
-            # Convert array to string (makes comparison easy)
-            $correctDNSString = ($correctDNS | Sort-Object | Get-Unique) -join ','
             
             # Find out what SANs are on the current cert
             $currentSanList = ($cert.Extensions | Where {$_.oid.FriendlyName -match 'Subject Alternative Name'}).Format(1).split("`n").TrimEnd()
@@ -773,11 +771,9 @@ function Test-TargetResource
                     $currentDNS += $san.split('=')[1]
                 }
             }
-            # Convert array to string (makes comparison easy)
-            $currentDNSString = ($currentDNS | Sort-Object | Get-Unique) -join ','
-            
+
             # Do the cert's DNS SANs and the desired DNS SANs match?
-            if ($currentDNSString -ne $correctDNSString) {
+            if (@(Compare-Object -ReferenceObject $currentDNS -DifferenceObject $correctDNS).Count -gt 0) {
                 return $false
             }
         }

--- a/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
+++ b/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
@@ -777,7 +777,7 @@ function Test-TargetResource
 			$CurrentDNSString = ($CurrentDNS | Sort-Object | Get-Unique) -join ','
 			
 			# Do the cert's DNS SANs and the desired DNS SANs match?
-			if ($CurrentDNS -ne $CorrectDNS) {
+			if ($CurrentDNSString -ne $CorrectDNSString) {
 				return $false
 			}
 		}

--- a/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
+++ b/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
@@ -751,36 +751,36 @@ function Test-TargetResource
             } # if
         } # if
 
-		if ($PSBoundParameters.ContainsKey('SubjectAltName')) {
-			# Split the desired SANs into an array
-			$SanList = $SubjectAltName.Split('&')
-			$CorrectDNS = @()
-			foreach ($San in $SanList) {
-				if ($San -like 'dns*') {
-					# This SAN is a DNS name
-					$CorrectDNS += $San.split('=')[1]
-				}
-			}
-			# Convert array to string (makes comparison easy)
-			$CorrectDNSString = ($CorrectDNS | Sort-Object | Get-Unique) -join ','
-			
-			# Find out what SANs are on the current cert
-			$CurrentSanList = ($cert.Extensions | Where {$_.oid.FriendlyName -match 'Subject Alternative Name'}).Format(1).split("`n").TrimEnd()
-			$CurrentDNS = @()
-			foreach ($San in $CurrentSanList) {
-				if ($San -like 'dns*') {
-					# This SAN is a DNS name
-					$CurrentDNS += $San.split('=')[1]
-				}
-			}
-			# Convert array to string (makes comparison easy)
-			$CurrentDNSString = ($CurrentDNS | Sort-Object | Get-Unique) -join ','
-			
-			# Do the cert's DNS SANs and the desired DNS SANs match?
-			if ($CurrentDNSString -ne $CorrectDNSString) {
-				return $false
-			}
-		}
+        if ($PSBoundParameters.ContainsKey('SubjectAltName')) {
+            # Split the desired SANs into an array
+            $SanList = $SubjectAltName.Split('&')
+            $CorrectDNS = @()
+            foreach ($San in $SanList) {
+                if ($San -like 'dns*') {
+                    # This SAN is a DNS name
+                    $CorrectDNS += $San.split('=')[1]
+                }
+            }
+            # Convert array to string (makes comparison easy)
+            $CorrectDNSString = ($CorrectDNS | Sort-Object | Get-Unique) -join ','
+            
+            # Find out what SANs are on the current cert
+            $CurrentSanList = ($cert.Extensions | Where {$_.oid.FriendlyName -match 'Subject Alternative Name'}).Format(1).split("`n").TrimEnd()
+            $CurrentDNS = @()
+            foreach ($San in $CurrentSanList) {
+                if ($San -like 'dns*') {
+                    # This SAN is a DNS name
+                    $CurrentDNS += $San.split('=')[1]
+                }
+            }
+            # Convert array to string (makes comparison easy)
+            $CurrentDNSString = ($CurrentDNS | Sort-Object | Get-Unique) -join ','
+            
+            # Do the cert's DNS SANs and the desired DNS SANs match?
+            if ($CurrentDNSString -ne $CorrectDNSString) {
+                return $false
+            }
+        }
 
         # The certificate was found and is OK - so no change required.
         Write-Verbose -Message ( @(

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -79,6 +79,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### Unreleased
 - Added mandatory properties for xPfxImport resource example.
+- Fixed issue where xCertReq does not identify when DNS Names in SANs are incorrect.
 
 ### 2.5.0.0
 - Fixed issue where xCertReq does not process requested certificate when credentials parameter set and PSDscRunAsCredential not passed. See [issue](https://github.com/PowerShell/xCertificate/issues/49)

--- a/Tests/Unit/MSFT_xCertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_xCertReq.Tests.ps1
@@ -93,7 +93,7 @@ try
         $OID                   = '1.3.6.1.5.5.7.3.1'
         $KeyUsage              = '0xa0'
         $CertificateTemplate   = 'WebServer'
-		$SubjectAltUrl         = 'contoso.com'
+        $SubjectAltUrl         = 'contoso.com'
         $SubjectAltName        = "dns=$SubjectAltUrl"
 
         $validCert      = New-Object -TypeName PSObject -Property @{
@@ -126,46 +126,46 @@ try
         Add-Member -InputObject $expiredCert -MemberType ScriptMethod -Name Verify -Value {
             return $true
         }
-		$sanOid = New-Object -TypeName System.Security.Cryptography.Oid -Property @{FriendlyName = 'Subject Alternative Name'}
-		$sanExt = @{
-			oid = $(,$sanOid)    
-			Critical = $false
-		}
-		Add-Member -InputObject $sanExt -MemberType ScriptMethod -Name Format -Force -Value {
+        $sanOid = New-Object -TypeName System.Security.Cryptography.Oid -Property @{FriendlyName = 'Subject Alternative Name'}
+        $sanExt = @{
+            oid = $(,$sanOid)    
+            Critical = $false
+        }
+        Add-Member -InputObject $sanExt -MemberType ScriptMethod -Name Format -Force -Value {
             return "DNS Name=$SubjectAltUrl"
         }
-		$validSANCert      = New-Object -TypeName PSObject -Property @{
+        $validSANCert      = New-Object -TypeName PSObject -Property @{
             Thumbprint     = $validThumbprint
             Subject        = "CN=$validSubject"
             Issuer         = $validIssuer
             NotBefore      = (Get-Date).AddDays(-30) # Issued on
             NotAfter       = (Get-Date).AddDays(31) # Expires after
-			Extensions     = $sanExt
+            Extensions     = $sanExt
         }
         Add-Member -InputObject $validSANCert -MemberType ScriptMethod -Name Verify -Value {
             return $true
         }
-		Add-Member -InputObject $sanExt -MemberType ScriptMethod -Name Format -Force -Value {
+        Add-Member -InputObject $sanExt -MemberType ScriptMethod -Name Format -Force -Value {
             return "DNS Name=incorrect.com"
         }
-		$incorrectSANCert  = New-Object -TypeName PSObject -Property @{
+        $incorrectSANCert  = New-Object -TypeName PSObject -Property @{
             Thumbprint     = $validThumbprint
             Subject        = "CN=$validSubject"
             Issuer         = $validIssuer
             NotBefore      = (Get-Date).AddDays(-30) # Issued on
             NotAfter       = (Get-Date).AddDays(31) # Expires after
-			Extensions     = $sanExt
+            Extensions     = $sanExt
         }
         Add-Member -InputObject $incorrectSANCert -MemberType ScriptMethod -Name Verify -Value {
             return $true
         }
-		$emptySANCert      = New-Object -TypeName PSObject -Property @{
+        $emptySANCert      = New-Object -TypeName PSObject -Property @{
             Thumbprint     = $validThumbprint
             Subject        = "CN=$validSubject"
             Issuer         = $validIssuer
             NotBefore      = (Get-Date).AddDays(-30) # Issued on
             NotAfter       = (Get-Date).AddDays(31) # Expires after
-			Extensions     = @()
+            Extensions     = @()
         }
         Add-Member -InputObject $emptySANCert -MemberType ScriptMethod -Name Verify -Value {
             return $true
@@ -868,17 +868,17 @@ RenewalCert = $validThumbprint
                 Mock Get-CertificateSan -MockWith { $SubjectAltName }
                 Test-TargetResource @ParamsAutoRenew | Should Be $true
             }
-			      It 'should return true when a valid certificate already exists and DNS SANs match' {
+                  It 'should return true when a valid certificate already exists and DNS SANs match' {
                 Mock Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
                     -Mockwith { $validSANCert }
                 Test-TargetResource @ParamsSubjectAltName | Should Be $true
             }
-			      It 'should return false when a certificate exists but contains incorrect DNS SANs' {
+                  It 'should return false when a certificate exists but contains incorrect DNS SANs' {
                 Mock Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
                     -Mockwith { $incorrectSANCert }
                 Test-TargetResource @ParamsSubjectAltName | Should Be $false
             }
-			      It 'should return false when a certificate exists but does not contain specified DNS SANs' {
+                  It 'should return false when a certificate exists but does not contain specified DNS SANs' {
                 Mock Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
                     -Mockwith { $emptySANCert }
                 Test-TargetResource @ParamsSubjectAltName | Should Be $false

--- a/Tests/Unit/MSFT_xCertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_xCertReq.Tests.ps1
@@ -145,7 +145,7 @@ try
         Add-Member -InputObject $validSANCert -MemberType ScriptMethod -Name Verify -Value {
             return $true
         }
-		$incorrectSanExt = @{
+        $incorrectSanExt = @{
             oid = $(,$sanOid)    
             Critical = $false
         }

--- a/Tests/Unit/MSFT_xCertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_xCertReq.Tests.ps1
@@ -145,7 +145,11 @@ try
         Add-Member -InputObject $validSANCert -MemberType ScriptMethod -Name Verify -Value {
             return $true
         }
-        Add-Member -InputObject $sanExt -MemberType ScriptMethod -Name Format -Force -Value {
+		$incorrectSanExt = @{
+            oid = $(,$sanOid)    
+            Critical = $false
+        }
+        Add-Member -InputObject $incorrectSanExt -MemberType ScriptMethod -Name Format -Force -Value {
             return "DNS Name=incorrect.com"
         }
         $incorrectSANCert  = New-Object -TypeName PSObject -Property @{
@@ -154,7 +158,7 @@ try
             Issuer         = $validIssuer
             NotBefore      = (Get-Date).AddDays(-30) # Issued on
             NotAfter       = (Get-Date).AddDays(31) # Expires after
-            Extensions     = $sanExt
+            Extensions     = $incorrectSanExt
         }
         Add-Member -InputObject $incorrectSANCert -MemberType ScriptMethod -Name Verify -Value {
             return $true


### PR DESCRIPTION
Adds code to Test-TargetResource to check that DNS Names in SANs are correct.
Does not handle other types of SANs, but a similar technique could probably be implemented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcertificate/62)
<!-- Reviewable:end -->
