### PR TITLE
Prevent ResourceHelper and Common cmdlets from being exported - Fixes #64

### DIFF
--- a/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
+++ b/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
@@ -1,9 +1,21 @@
 #Requires -Version 4.0
 
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the xCertificate Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xCertificate.psd1')
+# Import the Certificate Common Modules
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'CertificateDsc.Common' `
+                                                     -ChildPath 'CertificateDsc.Common.psm1'))
+
+# Import the Certificate Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'CertificateDsc.ResourceHelper' `
+                                                     -ChildPath 'CertificateDsc.ResourceHelper.psm1'))
+
+# Import the Certificate PDT Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'CertificateDsc.PDT' `
+                                                     -ChildPath 'CertificateDsc.PDT.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/DSCResources/MSFT_xCertificateExport/MSFT_xCertificateExport.psm1
+++ b/DSCResources/MSFT_xCertificateExport/MSFT_xCertificateExport.psm1
@@ -1,9 +1,16 @@
 #Requires -Version 4.0
 
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the xCertificate Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xCertificate.psd1')
+# Import the Certificate Common Modules
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'CertificateDsc.Common' `
+                                                     -ChildPath 'CertificateDsc.Common.psm1'))
+
+# Import the Certificate Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'CertificateDsc.ResourceHelper' `
+                                                     -ChildPath 'CertificateDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/DSCResources/MSFT_xCertificateImport/MSFT_xCertificateImport.psm1
+++ b/DSCResources/MSFT_xCertificateImport/MSFT_xCertificateImport.psm1
@@ -1,9 +1,16 @@
 #Requires -Version 4.0
 
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the xCertificate Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xCertificate.psd1')
+# Import the Certificate Common Modules
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'CertificateDsc.Common' `
+                                                     -ChildPath 'CertificateDsc.Common.psm1'))
+
+# Import the Certificate Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'CertificateDsc.ResourceHelper' `
+                                                     -ChildPath 'CertificateDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/DSCResources/MSFT_xPfxImport/MSFT_xPfxImport.psm1
+++ b/DSCResources/MSFT_xPfxImport/MSFT_xPfxImport.psm1
@@ -1,9 +1,16 @@
 #Requires -Version 4.0
 
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
 
-# Import the xCertificate Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xCertificate.psd1')
+# Import the Certificate Common Modules
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'CertificateDsc.Common' `
+                                                     -ChildPath 'CertificateDsc.Common.psm1'))
+
+# Import the Certificate Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+                               -ChildPath (Join-Path -Path 'CertificateDsc.ResourceHelper' `
+                                                     -ChildPath 'CertificateDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -74,10 +74,6 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ## Versions
 
-- Added integration test to test for conflicts with other common resource kit modules.
-- Prevented ResourceHelper and Common module cmdlets from being exported to resolve
-  conflicts with other resource modules.
-
 ### Unreleased
 
 - Converted AppVeyor build process to use AppVeyor.psm1.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -74,6 +74,10 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ## Versions
 
+- Added integration test to test for conflicts with other common resource kit modules.
+- Prevented ResourceHelper and Common module cmdlets from being exported to resolve
+  conflicts with other resource modules.
+
 ### Unreleased
 
 - Converted AppVeyor build process to use AppVeyor.psm1.
@@ -85,6 +89,9 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 - Converted AppVeyor.yml to use DSCResource.tests shared code.
 - Opted-In to markdown rule validation.
 - Examples modified to meet standards for auto documentation generation.
+- Added integration test to test for conflicts with other common resource kit modules.
+- Prevented ResourceHelper and Common module cmdlets from being exported to resolve
+  conflicts with other resource modules.
 
 ### 2.3.0.0
 

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -34,7 +34,7 @@ try
             It "Should be able to install DSC Resource module '$moduleToTest'" {
                 {
                     Install-Module -Name $moduleToTest -ErrorAction Stop
-                } | Should not throw
+                } | Should Not Throw
             }
         }
     }

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -1,0 +1,47 @@
+$script:DSCModuleName      = 'xCertificate'
+<#
+    These integration tests ensure that exported cmdlets names do not conflict
+    with any other names that are exposed by other common resource kit modules.
+#>
+$script:ModulesToTest = @( 'xNetworking','xComputerManagement','xDFS' )
+
+#region HEADER
+# Integration Test Template Version: 1.1.0
+[string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xCertificate'
+
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath "$($script:DSCModuleName).psd1") -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName 'All' `
+    -TestType Integration
+
+#endregion
+
+# Using try/finally to always cleanup even if something awful happens.
+try
+{
+    Describe "$($script:DSCModuleName)_CommonModuleConflict" {
+        
+        foreach ($moduleToTest in $script:ModulesToTest)
+        {
+            It "Should be able to install DSC Resource module '$moduleToTest'" {
+                {
+                    Install-Module -Name $moduleToTest -ErrorAction Stop
+                } | Should not throw
+            }
+        }
+    }
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -7,7 +7,7 @@ $script:ModulesToTest = @( 'xNetworking','xComputerManagement','xDFS' )
 
 #region HEADER
 # Integration Test Template Version: 1.1.0
-[string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xCertificate'
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
      (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )

--- a/xCertificate.psd1
+++ b/xCertificate.psd1
@@ -24,7 +24,7 @@
     CLRVersion = '4.0'
 
     # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-    NestedModules = @('Modules\CertificateDsc.Common\CertificateDsc.Common.psm1','Modules\CertificateDsc.ResourceHelper\CertificateDsc.ResourceHelper.psm1','Modules\CertificateDsc.PDT\CertificateDsc.PDT.psm1')
+    # NestedModules = @()
 
     # Functions to export from this module
     FunctionsToExport = '*'


### PR DESCRIPTION
This resolves a high priority issue with newer versions of xNetworking, xCertificate, xStorage and xDFS conflicting with each other because the ResourceHelper cmdlets are being exported due to the way each resource imported them (using the PSD1 nested modules array).

This should be resolved in xNetworking, xStorage and xDFS as well to ensure no other conflicts.

This also contains a new integration test that will check for any further conflicts between resource modules. At some point it might be possible to move this test into the DSCResource.Tests common tests to provide more comprehensive conflict prevention. However, because the conflicts will potentially be between three different modules the number of modules compared will have to go in over time.

This fixes #64

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcertificate/65)
<!-- Reviewable:end -->
