### PR TITLE
Fixed verbose preference not being passed to CertificateDsc.Common functions - Fixes #70

### DIFF
--- a/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
+++ b/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
@@ -379,7 +379,7 @@ function Find-CertificateAuthority
     )
 
     Write-Verbose `
-        -Message ($LocalizedData.StartLocateCA) `
+        -Message ($LocalizedData.StartLocateCAMessage) `
         -Verbose
 
     try

--- a/Modules/CertificateDsc.Common/en-us/CertificateDsc.Common.strings.psd1
+++ b/Modules/CertificateDsc.Common/en-us/CertificateDsc.Common.strings.psd1
@@ -6,7 +6,7 @@ ConvertFrom-StringData @'
     ConfigurationNamingContext          = Using the following container to look for CA candidates: 'LDAP://CN=CDP,CN=Public Key Services,CN=Services,{0}'
     ValidHashMessage                    = '{0}' is a valid {1} hash.
     DomainContactError                  = The domain '{0}' could not be contacted. The following error was received: '{1}'
-    StartLocateCA                       = Starting to locate CA
+    StartLocateCAMessage                = Starting to locate CA
     NoCaFoundError                      = No Certificate Authority could be found in Configuration Naming Context '{0}'
     CaPingMessage                       = certutil exited with code {0} and the following output:`r`n{1}
     CaFoundMessage                      = Found certificate authority {0}\{1}

--- a/Modules/CertificateDsc.Common/en-us/CertificateDsc.Common.strings.psd1
+++ b/Modules/CertificateDsc.Common/en-us/CertificateDsc.Common.strings.psd1
@@ -6,6 +6,7 @@ ConvertFrom-StringData @'
     ConfigurationNamingContext          = Using the following container to look for CA candidates: 'LDAP://CN=CDP,CN=Public Key Services,CN=Services,{0}'
     ValidHashMessage                    = '{0}' is a valid {1} hash.
     DomainContactError                  = The domain '{0}' could not be contacted. The following error was received: '{1}'
+    StartLocateCA                       = Starting to locate CA
     NoCaFoundError                      = No Certificate Authority could be found in Configuration Naming Context '{0}'
     CaPingMessage                       = certutil exited with code {0} and the following output:`r`n{1}
     CaFoundMessage                      = Found certificate authority {0}\{1}

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -149,6 +149,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   installed.
 - Added the VS Code PowerShell extension formatting settings that cause PowerShell
   files to be formatted as per the DSC Resource kit style guidelines.
+- Fixed verbose preference not being passed to CertificateDsc.Common functions -
+  fixes [Issue 70](https://github.com/PowerShell/xCertificate/issues/70).
 
 ### 2.7.0.0
 


### PR DESCRIPTION
The issue being fixed by this PR is that verbose messages in the Common functions would not be sent to the verbose stream, even if the resource is run with Verbose enabled.

This PR fixes that issue.

As discussed in: https://github.com/PowerShell/xSQLServer/issues/641

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcertificate/74)
<!-- Reviewable:end -->
