### PR TITLE
Converted to use exception code in ResourceHelper module - Fixes #68

### DIFF
--- a/DSCResources/MSFT_xCertificateImport/MSFT_xCertificateImport.psm1
+++ b/DSCResources/MSFT_xCertificateImport/MSFT_xCertificateImport.psm1
@@ -79,9 +79,9 @@ function Get-TargetResource
 
     if ((Test-Path $certificateStore) -eq $false)
     {
-        New-InvalidArgumentError `
-            -ErrorId 'CertificateStoreNotFound' `
-            -ErrorMessage ($LocalizedData.CertificateStoreNotFoundError -f $certificateStore)
+        New-InvalidArgumentException `
+            -Message ($LocalizedData.CertificateStoreNotFoundError -f $certificateStore) `
+            -ArgumentName 'Store'
     }
 
     $checkEnsure = [Bool] (

--- a/DSCResources/MSFT_xPfxImport/MSFT_xPfxImport.psm1
+++ b/DSCResources/MSFT_xPfxImport/MSFT_xPfxImport.psm1
@@ -94,7 +94,7 @@ function Get-TargetResource
     if ((Test-Path $certificateStore) -eq $false)
     {
         New-InvalidArgumentException `
-            -ErrorMessage ($LocalizedData.CertificateStoreNotFoundError -f $certificateStore) `
+            -Message ($LocalizedData.CertificateStoreNotFoundError -f $certificateStore) `
             -ArgumentName 'Store'
     }
 

--- a/DSCResources/MSFT_xPfxImport/MSFT_xPfxImport.psm1
+++ b/DSCResources/MSFT_xPfxImport/MSFT_xPfxImport.psm1
@@ -93,9 +93,9 @@ function Get-TargetResource
 
     if ((Test-Path $certificateStore) -eq $false)
     {
-        New-InvalidArgumentError `
-            -ErrorId 'CertificateStoreNotFound' `
-            -ErrorMessage ($LocalizedData.CertificateStoreNotFoundError -f $certificateStore)
+        New-InvalidArgumentException `
+            -ErrorMessage ($LocalizedData.CertificateStoreNotFoundError -f $certificateStore) `
+            -ArgumentName 'Store'
     }
 
     $checkEnsure = [Bool](

--- a/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
+++ b/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
@@ -61,9 +61,9 @@ function Test-CertificatePath
             }
             else
             {
-                New-InvalidArgumentError `
-                    -ErrorId 'CannotFindRootedPath' `
-                    -ErrorMessage ($LocalizedData.FileNotFoundError -f $pathNode)
+                New-InvalidArgumentException `
+                    -Message ($LocalizedData.FileNotFoundError -f $pathNode) `
+                    -ArgumentName 'Path'
             }
         }
     }
@@ -160,9 +160,8 @@ function Test-Thumbprint
             }
             else
             {
-                New-InvalidArgumentError `
-                    -ErrorId 'CannotFindRootedPath' `
-                    -ErrorMessage ($LocalizedData.InvalidHashError -f $hash)
+                New-InvalidOperationException `
+                    -Message ($LocalizedData.InvalidHashError -f $hash)
             }
         }
     }
@@ -252,9 +251,9 @@ function Find-Certificate
     if (-not (Test-Path -Path $certPath))
     {
         # The Certificte Path is not valid
-        New-InvalidArgumentError `
-            -ErrorId 'CannotFindCertificatePath' `
-            -ErrorMessage ($LocalizedData.CertificatePathError -f $certPath)
+        New-InvalidArgumentException `
+            -Message ($LocalizedData.CertificatePathError -f $certPath)
+            -ArgumnentName 'Store'
     } # if
 
     # Assemble the filter to use to select the certificate
@@ -537,37 +536,3 @@ function Get-CertificateSan
 
     return $subjectAlternativeName
 }
-
-<#
-    .SYNOPSIS
-    Throws an InvalidArgument custom exception.
-
-    .PARAMETER ErrorId
-    The error Id of the exception.
-
-    .PARAMETER ErrorMessage
-    The error message text to set in the exception.
-#>
-function New-InvalidArgumentError
-{
-    [CmdletBinding()]
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $ErrorId,
-
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $ErrorMessage
-    )
-
-    $exception = New-Object -TypeName System.ArgumentException `
-        -ArgumentList $ErrorMessage
-    $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidArgument
-    $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-        -ArgumentList $exception, $ErrorId, $errorCategory, $null
-    throw $errorRecord
-} # end function New-InvalidArgumentError

--- a/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
+++ b/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
@@ -252,7 +252,7 @@ function Find-Certificate
     {
         # The Certificte Path is not valid
         New-InvalidArgumentException `
-            -Message ($LocalizedData.CertificatePathError -f $certPath)
+            -Message ($LocalizedData.CertificatePathError -f $certPath) `
             -ArgumnentName 'Store'
     } # if
 

--- a/Modules/CertificateDsc.PDT/CertificateDsc.PDT.psm1
+++ b/Modules/CertificateDsc.PDT/CertificateDsc.PDT.psm1
@@ -730,16 +730,14 @@ function Wait-Win32ProcessEnd
     # Wait for the process to start
     if (-not (Wait-Win32ProcessStart @getArguments))
     {
-        New-InvalidArgumentError `
-            -ErrorId 'ProcessFailedToStartError' `
-            -ErrorMessage ($LocalizedData.ProcessFailedToStartError -f $Path,$Arguments)
+        New-InvalidOperationException `
+            -Message ($LocalizedData.ProcessFailedToStartError -f $Path,$Arguments)
     }
     if (-not (Wait-Win32ProcessStop @getArguments))
     {
         # The process did not stop.
-        New-InvalidArgumentError `
-            -ErrorId 'ProcessFailedToStopError' `
-            -ErrorMessage ($LocalizedData.ProcessFailedToStopError -f $Path,$Arguments)
+        New-InvalidOperationException `
+            -Message ($LocalizedData.ProcessFailedToStopError -f $Path,$Arguments)
     }
 } # end function Wait-Win32ProcessEnd
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -151,6 +151,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   files to be formatted as per the DSC Resource kit style guidelines.
 - Fixed verbose preference not being passed to CertificateDsc.Common functions -
   fixes [Issue 70](https://github.com/PowerShell/xCertificate/issues/70).
+- Converted all calls to `New-InvalidArgumentError` function to `New-InvalidArgumentException`
+  found in `CertificateDsc.ResourceHelper` - fixes [Issue 68](https://github.com/PowerShell/xCertificate/issues/68)
 
 ### 2.7.0.0
 


### PR DESCRIPTION
This module was using several different functions to raise exceptions. This resulted in additional code and extra complexity.

This PR converts all exception calls to use the standard functions in CertificateDsc.ResourceHelper (which are copied from PSDscResources) and removes the no longer used function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcertificate/77)
<!-- Reviewable:end -->
