### PR TITLE
BREAKING CHANGE: Change Default Key Length to 2048 bits in xCertReq - Fixes #82

### DIFF
--- a/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
+++ b/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
@@ -70,7 +70,7 @@ $localizedData = Get-LocalizedData `
 
     .PARAMETER CesURL
     The URL to the Certification Enrollment Service.
-    
+
     .PARAMETER UseMachineContext
     Determines if the machine should be impersonated for a request. Used for templates like Domain Controller Authentication
 
@@ -99,7 +99,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet("1024","2048","4096","8192")]
         [System.String]
-        $KeyLength = '1024',
+        $KeyLength = '2048',
 
         [Parameter()]
         [System.Boolean]
@@ -260,13 +260,13 @@ function Get-TargetResource
 
     .PARAMETER CAType
     The type of CA in use, Standalone/Enterprise.
- 
+
     .PARAMETER CepURL
     The URL to the Certification Enrollment Policy Service.
 
     .PARAMETER CesURL
     The URL to the Certification Enrollment Service.
-    
+
     .PARAMETER UseMachineContext
     Determines if the machine should be impersonated for a request. Used for templates like Domain Controller Authentication
 
@@ -294,7 +294,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet("1024","2048","4096","8192")]
         [System.String]
-        $KeyLength = '1024',
+        $KeyLength = '2048',
 
         [Parameter()]
         [System.Boolean]
@@ -365,7 +365,7 @@ function Set-TargetResource
         $CARootName = $caObject.CARootName
         $CAServerFQDN = $caObject.CAServerFQDN
     }
-    
+
     $ca = "$CAServerFQDN\$CARootName"
 
     Write-Verbose -Message ( @(
@@ -410,7 +410,7 @@ function Set-TargetResource
     $useExistingKeySet   = 'FALSE'
     $providerType        = '12'
     $requestType         = 'CMC'
-    
+
     # A unique identifier for temporary files that will be used when interacting with the command line utility
     $guid = [system.guid]::NewGuid().guid
     $workingPath = Join-Path -Path $env:Temp -ChildPath "xCertReq-$guid"
@@ -484,7 +484,7 @@ RenewalCert = $Thumbprint
         Syntax: https://technet.microsoft.com/en-us/library/cc736326.aspx
         Reference: https://support2.microsoft.com/default.aspx?scid=kb;EN-US;321051
     #>
-    
+
     # NEW: Create a new request as directed by PolicyFileIn
     Write-Verbose -Message ( @(
             "$($MyInvocation.MyCommand): "
@@ -508,7 +508,7 @@ RenewalCert = $Thumbprint
             $reqPath
         )
     }
-    else 
+    else
     {
         $createRequest = & certreq.exe @('-new','-q',$infPath,$reqPath)
     } # if
@@ -545,12 +545,12 @@ RenewalCert = $Thumbprint
                     '-username', $Credential.UserName,
                     '-p', [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($credPW),
                     '-PolicyServer', $CepURL,
-                    '-config', $CesURL,  
+                    '-config', $CesURL,
                     $ReqPath,
                     $CerPath
                 )
             }
-            else 
+            else
             {
                 <#
                     Assemble the command and arguments to pass to the powershell process that
@@ -696,7 +696,7 @@ RenewalCert = $Thumbprint
 
     .PARAMETER CesURL
     The URL to the Certification Enrollment Service.
-    
+
     .PARAMETER UseMachineContext
     Determines if the machine should be impersonated for a request. Used for templates like Domain Controller Authentication
 
@@ -725,7 +725,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet("1024","2048","4096","8192")]
         [System.String]
-        $KeyLength = '1024',
+        $KeyLength = '2048',
 
         [Parameter()]
         [System.Boolean]
@@ -796,7 +796,7 @@ function Test-TargetResource
         $CARootName = $caObject.CARootName
         $CAServerFQDN = $caObject.CAServerFQDN
     }
-    
+
     $ca = "$CAServerFQDN\$CARootName"
 
     # If the Subject does not contain a full X500 path, construct just the CN
@@ -876,7 +876,7 @@ function Test-TargetResource
                     $correctDNS += $san.split('=')[1]
                 }
             }
-            
+
             # Find out what SANs are on the current cert
             if ($cert.Extensions.Count -gt 0)
             {

--- a/DSCResources/MSFT_xCertReq/MSFT_xCertReq.schema.mof
+++ b/DSCResources/MSFT_xCertReq/MSFT_xCertReq.schema.mof
@@ -5,13 +5,13 @@ class MSFT_xCertReq : OMI_BaseResource
     [Write, Description("The type of CA in use, Standalone/Enterprise.")] String CAType;
     [Write, Description("The FQDN of the Active Directory Certificate Authority on the local area network. Leave empty to automatically locate.")] String CAServerFQDN;
     [Write, Description("The name of the certificate authority, by default this will be in format domain-servername-ca. Leave empty to automatically locate.")] String CARootName;
-    [Write, Description("The bit length of the encryption key to be used"), ValueMap{"1024","2048","4096","8192"}, Values{"1024","2048","4096","8192"}] String KeyLength;
+    [Write, Description("The bit length of the encryption key to be used. Defaults to 2048."), ValueMap{"1024","2048","4096","8192"}, Values{"1024","2048","4096","8192"}] String KeyLength;
     [Write, Description("The option to allow the certificate to be exportable, by default it will be true.")] Boolean Exportable;
     [Write, Description("The selection of provider for the type of encryption to be used.")] String ProviderName;
     [Write, Description("The Object Identifier that is used to name the object.")] String OID;
     [Write, Description("The Keyusage is a restriction method that determines what a certificate can be used for.")] String KeyUsage;
-    [Write, Description("The template used for the definiton of the certificate.")] String CertificateTemplate;
-    [Write, Description("The subject alternative name used to createthe certificate.")] String SubjectAltName;
+    [Write, Description("The template used for the definition of the certificate.")] String CertificateTemplate;
+    [Write, Description("The subject alternative name used to create the certificate.")] String SubjectAltName;
     [Write, Description("The credentials that will be used to access the template in the Certificate Authority."), EmbeddedInstance("MSFT_Credential")] String Credential;
     [Write, Description("Determines if the resource will also renew a certificate within 7 days of expiration.")] Boolean AutoRenew;
     [Write, Description("The URL to the Certification Enrollment Policy Service.")] String CepURL;

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Michael Greene
+Copyright (c) 2017 Microsoft Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -170,7 +170,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 - Fixed bugs in examples.
 - Updated License and Manifest Copyright info to be 2017 Microsoft Corporation.
 - xCertReq:
-  - BREAKING CHANGE: Changed default Keylength to 2048 bits to meet [Microsoft Security Advisory](https://support.microsoft.com/en-nz/help/2661254/microsoft-security-advisory-update-for-minimum-certificate-key-length).
+  - BREAKING CHANGE: Changed default Keylength to 2048 bits to meet [Microsoft Security Advisory](https://support.microsoft.com/en-us/help/2661254/microsoft-security-advisory-update-for-minimum-certificate-key-length).
   - Fixed spelling mistakes in MOF files.
 
 ### 2.8.0.0

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -170,7 +170,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 - Fixed bugs in examples.
 - Updated License and Manifest Copyright info to be 2017 Microsoft Corporation.
 - xCertReq:
-  - BREAKING CHANGE: Changed default Keylength to 2048 bits to meet [Microsoft Security Advisory](https://support.microsoft.com/en-us/help/2661254/microsoft-security-advisory-update-for-minimum-certificate-key-length).
+  - BREAKING CHANGE: Changed default Keylength to 2048 bits to meet
+    [Microsoft Security Advisory](https://support.microsoft.com/en-us/help/2661254/microsoft-security-advisory-update-for-minimum-certificate-key-length).
   - Fixed spelling mistakes in MOF files.
 
 ### 2.8.0.0

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -56,7 +56,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   this will be in format domain-servername-ca. Leave empty to auto-discover in
   an Active Directory environment.
 - **`[String]` KeyLength**: The bit length of the encryption key to be used.
-  Optional. { *1024* | 2048 | 4096 | 8192 }.
+  Optional. { 1024 | *2048* | 4096 | 8192 }.
 - **`[Boolean]` Exportable**: The option to allow the certificate to be exportable,
   by default it will be true. Optional. Defaults to `$true`.
 - **`[String]` ProviderName**: The selection of provider for the type of encryption
@@ -168,6 +168,10 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 - Add CodeCov.io code coverage reporting.
 - Opted into 'Common Tests - Validate Example Files'.
 - Fixed bugs in examples.
+- Updated License and Manifest Copyright info to be 2017 Microsoft Corporation.
+- xCertReq:
+  - BREAKING CHANGE: Changed default Keylength to 2048 bits to meet [Microsoft Security Advisory](https://support.microsoft.com/en-nz/help/2661254/microsoft-security-advisory-update-for-minimum-certificate-key-length).
+  - Fixed spelling mistakes in MOF files.
 
 ### 2.8.0.0
 

--- a/xCertificate.psd1
+++ b/xCertificate.psd1
@@ -12,7 +12,7 @@
     CompanyName = 'Microsoft Corporation'
 
     # Copyright statement for this module
-    Copyright = '(c) 2015 Microsoft Corporation. All rights reserved.'
+    Copyright = '(c) 2017 Microsoft Corporation. All rights reserved.'
 
     # Description of the functionality provided by this module
     Description = 'This module includes DSC resources that simplify administration of certificates on a Windows Server'


### PR DESCRIPTION
Key Lengths of 1024 bits are now considered to broken. Therefore we should not be using that as the default key length.

See [Microsoft Security Advisory](https://support.microsoft.com/en-nz/help/2661254/microsoft-security-advisory-update-for-minimum-certificate-key-length).

This PR changes the default value to 1024 bits. Although in most cases this is not a **breaking change**, if users have been using the default key length then this may prevent some systems from using the certificates. Also, certificate templates may be setup that prohibit the issuance of more than 1024 bits (for one reason or another). So I think we should consider this a breaking change.

I also took this opportunity to correct the license info and copyright years in the Manifest and License to be 2017 and Microsoft Corporation.

I also corrected a couple of spelling mistakes in the xCertReq MOF file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcertificate/88)
<!-- Reviewable:end -->
