### PR TITLE
Improve Wiki documentation generation for Credential parameters - Fixes #103

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   [issue #98](https://github.com/PowerShell/xCertificate/issues/98).
 - Changed description in Credential parameter of xPfxImport resource
   to correctly generate parameter documentation in Wiki - see [Issue #103](https://github.com/PowerShell/xCertificate/issues/103).
+- Changed description in Credential parameter of xCertReq resource
+  to clarify that a PSCredential object should be used.
 
 ## 3.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Added `Documentation and Examples` section to Readme.md file - see
   [issue #98](https://github.com/PowerShell/xCertificate/issues/98).
+- Changed description in Credential parameter of xPfxImport resource
+  to correctly generate parameter documentation in Wiki - see [Issue #103](https://github.com/PowerShell/xCertificate/issues/103).
 
 ## 3.0.0.0
 

--- a/Modules/xCertificate/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
+++ b/Modules/xCertificate/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
@@ -57,7 +57,7 @@ $localizedData = Get-LocalizedData `
     The subject alternative name used to createthe certificate.
 
     .PARAMETER Credential
-    The credentials that will be used to access the template in the Certificate Authority.
+    The `PSCredential` object containing the credentials that will be used to access the template in the Certificate Authority.
 
     .PARAMETER AutoRenew
     Determines if the resource will also renew a certificate within 7 days of expiration.
@@ -253,7 +253,7 @@ function Get-TargetResource
     The subject alternative name used to createthe certificate.
 
     .PARAMETER Credential
-    The credentials that will be used to access the template in the Certificate Authority.
+    The `PSCredential` object containing the credentials that will be used to access the template in the Certificate Authority.
 
     .PARAMETER AutoRenew
     Determines if the resource will also renew a certificate within 7 days of expiration.
@@ -683,7 +683,7 @@ RenewalCert = $Thumbprint
     The subject alternative name used to createthe certificate.
 
     .PARAMETER Credential
-    The credentials that will be used to access the template in the Certificate Authority.
+    The `PSCredential` object containing the credentials that will be used to access the template in the Certificate Authority.
 
     .PARAMETER AutoRenew
     Determines if the resource will also renew a certificate within 7 days of expiration.

--- a/Modules/xCertificate/DSCResources/MSFT_xCertReq/MSFT_xCertReq.schema.mof
+++ b/Modules/xCertificate/DSCResources/MSFT_xCertReq/MSFT_xCertReq.schema.mof
@@ -12,7 +12,7 @@ class MSFT_xCertReq : OMI_BaseResource
     [Write, Description("The Keyusage is a restriction method that determines what a certificate can be used for.")] String KeyUsage;
     [Write, Description("The template used for the definition of the certificate.")] String CertificateTemplate;
     [Write, Description("The subject alternative name used to create the certificate.")] String SubjectAltName;
-    [Write, Description("The credentials that will be used to access the template in the Certificate Authority."), EmbeddedInstance("MSFT_Credential")] String Credential;
+    [Write, Description("The `PSCredential` object containing the credentials that will be used to access the template in the Certificate Authority."), EmbeddedInstance("MSFT_Credential")] String Credential;
     [Write, Description("Determines if the resource will also renew a certificate within 7 days of expiration.")] Boolean AutoRenew;
     [Write, Description("The URL to the Certification Enrollment Policy Service.")] String CepURL;
     [Write, Description("The URL to the Certification Enrollment Service.")] String CesURL;

--- a/Modules/xCertificate/DSCResources/MSFT_xPfxImport/MSFT_xPfxImport.psm1
+++ b/Modules/xCertificate/DSCResources/MSFT_xPfxImport/MSFT_xPfxImport.psm1
@@ -37,7 +37,7 @@ $localizedData = Get-LocalizedData `
     Determines whether the private key is exportable from the machine after it has been imported.
 
     .PARAMETER Credential
-    A [PSCredential] object that is used to decrypt the PFX file. Only the password is used, so any user name is valid.
+    A `PSCredential` object that is used to decrypt the PFX file. Only the password is used, so any user name is valid.
 
     .PARAMETER Ensure
     Specifies whether the PFX file should be present or absent.
@@ -142,7 +142,7 @@ function Get-TargetResource
     Determines whether the private key is exportable from the machine after it has been imported.
 
     .PARAMETER Credential
-    A [PSCredential] object that is used to decrypt the PFX file. Only the password is used, so any user name is valid.
+    A `PSCredential` object that is used to decrypt the PFX file. Only the password is used, so any user name is valid.
 
     .PARAMETER Ensure
     Specifies whether the PFX file should be present or absent.
@@ -226,7 +226,7 @@ function Test-TargetResource
     Determines whether the private key is exportable from the machine after it has been imported.
 
     .PARAMETER Credential
-    A [PSCredential] object that is used to decrypt the PFX file. Only the password is used, so any user name is valid.
+    A `PSCredential` object that is used to decrypt the PFX file. Only the password is used, so any user name is valid.
 
     .PARAMETER Ensure
     Specifies whether the PFX file should be present or absent.

--- a/Modules/xCertificate/DSCResources/MSFT_xPfxImport/MSFT_xPfxImport.schema.mof
+++ b/Modules/xCertificate/DSCResources/MSFT_xPfxImport/MSFT_xPfxImport.schema.mof
@@ -6,6 +6,6 @@ class MSFT_xPfxImport : OMI_BaseResource
     [Key,Description("The Windows Certificate Store Location to import the PFX file to."),ValueMap{"LocalMachine", "CurrentUser"},Values{"LocalMachine", "CurrentUser"}] string Location;
     [Key,Description("The Windows Certificate Store Name to import the PFX file to.")] string Store;
     [write,Description("Determines whether the private key is exportable from the machine after it has been imported")] boolean Exportable;
-    [write,Description("A [PSCredential] object that is used to decrypt the PFX file."),EmbeddedInstance("MSFT_Credential")] string Credential;
+    [write,Description("A `PSCredential` object that is used to decrypt the PFX file."),EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write,Description("Specifies whether the PFX file should be present or absent."),ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;
 };


### PR DESCRIPTION
**Pull Request (PR) description**
- Changed description in Credential parameter of xPfxImport resource
  to correctly generate parameter documentation in Wiki - see [Issue #103](https://github.com/PowerShell/xCertificate/issues/103).
- Changed description in Credential parameter of xCertReq resource
  to clarify that a PSCredential object should be used.

**This Pull Request (PR) fixes the following issues:**
Fixes #103

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcertificate/104)
<!-- Reviewable:end -->
