### PR TITLE
Added support for WS 2008R2 for xCertificateImport and xPfxImport - Fixes #46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Changed description in Credential parameter of xCertReq resource
   to clarify that a PSCredential object should be used.
 - Updated tests to meet Pester V4 guidelines - fixes [Issue #105](https://github.com/PowerShell/xCertificate/issues/105).
+- Add support for Windows Server 2008 R2 which does not contain PKI
+  module so is missing `Import-PfxCertificate` and `Import-Certificate`
+  cmdlets - fixes [Issue #46](https://github.com/PowerShell/xCertificate/issues/46).
 
 ## 3.0.0.0
 

--- a/Modules/xCertificate/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
+++ b/Modules/xCertificate/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
@@ -54,7 +54,7 @@ $localizedData = Get-LocalizedData `
     The template used for the definiton of the certificate.
 
     .PARAMETER SubjectAltName
-    The subject alternative name used to createthe certificate.
+    The subject alternative name used to creat ethe certificate.
 
     .PARAMETER Credential
     The `PSCredential` object containing the credentials that will be used to access the template in the Certificate Authority.
@@ -250,7 +250,7 @@ function Get-TargetResource
     The template used for the definiton of the certificate.
 
     .PARAMETER SubjectAltName
-    The subject alternative name used to createthe certificate.
+    The subject alternative name used to create the certificate.
 
     .PARAMETER Credential
     The `PSCredential` object containing the credentials that will be used to access the template in the Certificate Authority.
@@ -680,7 +680,7 @@ RenewalCert = $Thumbprint
     The template used for the definiton of the certificate.
 
     .PARAMETER SubjectAltName
-    The subject alternative name used to createthe certificate.
+    The subject alternative name used to create the certificate.
 
     .PARAMETER Credential
     The `PSCredential` object containing the credentials that will be used to access the template in the Certificate Authority.

--- a/Modules/xCertificate/DSCResources/MSFT_xCertificateImport/MSFT_xCertificateImport.psm1
+++ b/Modules/xCertificate/DSCResources/MSFT_xCertificateImport/MSFT_xCertificateImport.psm1
@@ -246,13 +246,21 @@ function Set-TargetResource
                     $($LocalizedData.ImportingCertficateMessage -f $Path,$certificateStore)
                 ) -join '' )
 
-            $param = @{
+            $importCertificateParameters = @{
                 CertStoreLocation = $certificateStore
                 FilePath          = $Path
                 Verbose           = $VerbosePreference
             }
 
-            Import-Certificate @param
+            # If the built in PKI cmdlet exists then use that, otherwise command in Common module.
+            if (Test-CommandExists -Name 'Import-Certificate')
+            {
+                Import-Certificate @importCertificateParameters
+            }
+            else
+            {
+                Import-CertificateEx @importCertificateParameters
+            }
         }
     }
     elseif ($Ensure -ieq 'Absent')

--- a/Modules/xCertificate/DSCResources/MSFT_xPfxImport/MSFT_xPfxImport.psm1
+++ b/Modules/xCertificate/DSCResources/MSFT_xPfxImport/MSFT_xPfxImport.psm1
@@ -290,16 +290,26 @@ function Set-TargetResource
                     $($LocalizedData.ImportingPfxMessage -f $Path, $certificateStore)
                 ) -join '' )
 
-            $param = @{
+            $importPfxCertificateParameters = @{
                 Exportable        = $Exportable
                 CertStoreLocation = $certificateStore
                 FilePath          = $Path
             }
+
             if ($Credential)
             {
-                $param['Password'] = $Credential.Password
+                $importPfxCertificateParameters['Password'] = $Credential.Password
             }
-            Import-PfxCertificate @param
+
+            # If the built in PKI cmdlet exists then use that, otherwise command in Common module.
+            if (Test-CommandExists -Name 'Import-PfxCertificate')
+            {
+                Import-PfxCertificate @importPfxCertificateParameters
+            }
+            else
+            {
+                Import-PfxCertificateEx @importPfxCertificateParameters
+            }
         }
     }
     elseif ($Ensure -ieq 'Absent')

--- a/Modules/xCertificate/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
+++ b/Modules/xCertificate/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
@@ -651,7 +651,8 @@ function Import-CertificateEx
 
 <#
     .SYNOPSIS
-        This function imports a Pfx publiic - private certificate to the specific Certificate Store Location.
+        This function imports a Pfx public - private certificate to the specific
+        Certificate Store Location.
 
     .PARAMETER FilePath
         The path to the certificate file to import.
@@ -660,10 +661,10 @@ function Import-CertificateEx
         The Certificate Store and Location Path to import the certificate to.
 
     .PARAMETER Exportable
-        The paremter controls if certificate will be able to export the private key.
+        The parameter controls if certificate will be able to export the private key.
 
     .PARAMETER Password
-        The password that the Certificate located at the FilePath needs to be imported.
+        The password that the certificate located at the FilePath needs to be imported.
   #>
 
 function Import-PfxCertificateEx
@@ -692,7 +693,6 @@ function Import-PfxCertificateEx
     $store = Split-Path -Path $CertStoreLocation -Leaf
 
     $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
-    [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
 
     $flags = [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet
 

--- a/Modules/xCertificate/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
+++ b/Modules/xCertificate/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
@@ -1,7 +1,7 @@
 # Import the Networking Resource Helper Module
 Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
-                               -ChildPath (Join-Path -Path 'CertificateDsc.ResourceHelper' `
-                                                     -ChildPath 'CertificateDsc.ResourceHelper.psm1'))
+        -ChildPath (Join-Path -Path 'CertificateDsc.ResourceHelper' `
+            -ChildPath 'CertificateDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `
@@ -38,7 +38,7 @@ function Test-CertificatePath
     param
     (
         [Parameter(Mandatory = $true,
-                   ValueFromPipeline)]
+            ValueFromPipeline)]
         [String[]]
         $Path,
 
@@ -101,7 +101,7 @@ function Test-Thumbprint
     param
     (
         [Parameter(Mandatory = $true,
-                   ValueFromPipeline)]
+            ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [String[]]
         $Thumbprint,
@@ -116,9 +116,9 @@ function Test-Thumbprint
         # Get a list of Hash Providers
         $hashProviders = [System.AppDomain]::CurrentDomain.GetAssemblies().GetTypes() |
             Where-Object -FilterScript {
-                $_.BaseType.BaseType -eq [System.Security.Cryptography.HashAlgorithm] -and
-                ($_.Name -cmatch 'Managed$' -or $_.Name -cmatch 'Provider$')
-            }
+            $_.BaseType.BaseType -eq [System.Security.Cryptography.HashAlgorithm] -and
+            ($_.Name -cmatch 'Managed$' -or $_.Name -cmatch 'Provider$')
+        }
 
         # Get a list of all Valid Hash types and lengths into an array
         $validHashes = @()
@@ -128,10 +128,10 @@ function Test-Thumbprint
             $validHash = New-Object `
                 -TypeName PSObject `
                 -Property @{
-                    Hash      = $hashProvider.BaseType.Name
-                    BitSize   = $bitSize
-                    HexLength = $bitSize / 4
-                }
+                Hash      = $hashProvider.BaseType.Name
+                BitSize   = $bitSize
+                HexLength = $bitSize / 4
+            }
             $validHashes += @( $validHash )
         }
     }
@@ -147,7 +147,7 @@ function Test-Thumbprint
                 if ($hash -cmatch "^[a-fA-F0-9]{$($algorithm.HexLength)}$")
                 {
                     Write-Verbose `
-                        -Message ($LocalizedData.InvalidHashError -f $hash,$algorithm.Hash) `
+                        -Message ($LocalizedData.InvalidHashError -f $hash, $algorithm.Hash) `
                         -Verbose
 
                     $isValid = $true
@@ -302,7 +302,7 @@ function Find-Certificate
     $certFilterScript = '(' + ($certFilters -join ' -and ') + ')'
 
     Write-Verbose `
-        -Message ($LocalizedData.SearchingForCertificateUsingFilters -f $store,$certFilterScript) `
+        -Message ($LocalizedData.SearchingForCertificateUsingFilters -f $store, $certFilterScript) `
         -Verbose
 
     $certs = Get-ChildItem -Path $certPath |
@@ -399,7 +399,7 @@ function Find-CertificateAuthority
             $caRootName = ($item.Children.distinguishedName -split '=|,')[1]
 
             $certificateAuthority = [PSObject] @{
-                CARootName = $caRootName
+                CARootName   = $caRootName
                 CAServerFQDN = $caServerFQDN
             }
 
@@ -458,7 +458,7 @@ function Test-CertificateAuthority
 
     $locatorInfo = New-Object -TypeName System.Diagnostics.ProcessStartInfo
     $locatorInfo.FileName = 'certutil.exe'
-    $locatorInfo.Arguments = ('-ping "{0}\{1}"' -f $CAServerFQDN,$CARootName)
+    $locatorInfo.Arguments = ('-ping "{0}\{1}"' -f $CAServerFQDN, $CARootName)
 
     # Certutil does not make use of standard error stream
     $locatorInfo.RedirectStandardError = $false
@@ -584,4 +584,137 @@ function Get-CertificateSan
     }
 
     return $subjectAlternativeName
+}
+
+<#
+    .SYNOPSIS
+      Tests whether or not the command with the specified name exists.
+
+    .PARAMETER Name
+      The name of the command to test for.
+#>
+function Test-CommandExists
+{
+    [OutputType([System.Boolean])]
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Name
+    )
+
+    $command = Get-Command -Name $Name -ErrorAction 'SilentlyContinue'
+    return ($null -ne $command)
+}
+
+<#
+    .SYNOPSIS
+        This function imports a 509 public key certificate to the specific Store.
+
+    .PARAMETER FilePath
+        The path to the certificate file to import.
+
+    .PARAMETER CertStoreLocation
+        The Certificate Store and Location Path to import the certificate to.
+#>
+
+function Import-CertificateEx
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $FilePath,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $CertStoreLocation
+    )
+
+    $location = Split-Path -Path (Split-Path -Path $CertStoreLocation -Parent) -Leaf
+    $store = Split-Path -Path $CertStoreLocation -Leaf
+
+    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
+    $cert.Import($FilePath)
+
+    $certStore = New-Object `
+        -TypeName System.Security.Cryptography.X509Certificates.X509Store `
+        -ArgumentList ($store, $location)
+
+    $certStore.Open('MaxAllowed')
+    $certStore.Add($cert)
+    $certStore.Close()
+}
+
+<#
+    .SYNOPSIS
+        This function imports a Pfx publiic - private certificate to the specific Certificate Store Location.
+
+    .PARAMETER FilePath
+        The path to the certificate file to import.
+
+    .PARAMETER CertStoreLocation
+        The Certificate Store and Location Path to import the certificate to.
+
+    .PARAMETER Exportable
+        The paremter controls if certificate will be able to export the private key.
+
+    .PARAMETER Password
+        The password that the Certificate located at the FilePath needs to be imported.
+  #>
+
+function Import-PfxCertificateEx
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $FilePath,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $CertStoreLocation,
+
+        [Parameter(Mandatory = $false)]
+        [Switch]
+        $Exportable,
+
+        [Parameter(Mandatory = $false)]
+        [System.Security.SecureString]
+        $Password
+    )
+
+    $location = Split-Path -Path (Split-Path -Path $CertStoreLocation -Parent) -Leaf
+    $store = Split-Path -Path $CertStoreLocation -Leaf
+
+    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
+    [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
+
+    $flags = [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet
+
+    if ($Exportable)
+    {
+        $flags = $flags -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
+    }
+
+    if ($Password)
+    {
+        $cert.Import($FilePath, $Password, $flags)
+    }
+    else
+    {
+        $cert.Import($FilePath, $flags)
+    }
+
+    $certStore = New-Object `
+        -TypeName System.Security.Cryptography.X509Certificates.X509Store `
+        -ArgumentList @($store, $location)
+
+    $certStore.Open('MaxAllowed')
+    $certStore.Add($cert)
+    $certStore.Close()
 }

--- a/Tests/Integration/CertificateDsc.Common.Tests.ps1
+++ b/Tests/Integration/CertificateDsc.Common.Tests.ps1
@@ -1,0 +1,160 @@
+$script:ModuleName = 'CertificateDsc.Common'
+<#
+    These integration tests are the easiest way to effectively test the
+    Import-Certificate and Import-PfxCertificate cmdlets due to the use
+    of .NET objects to perform the work.
+
+    These tests are potentially destructive tests and so should not be
+    considered unit tests.
+#>
+
+#region HEADER
+# Integration Test Template Version: 1.1.0
+[String] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xCertificate'
+
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+Import-Module -Name (Join-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'Modules' -ChildPath $script:ModuleName)) -ChildPath "$script:ModuleName.psm1") -Force
+Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
+#endregion
+
+# Using try/finally to always cleanup even if something awful happens.
+try
+{
+    InModuleScope $script:ModuleName {
+        $ModuleName = 'CertificateDsc.Common'
+
+        <#
+            Generate a self-signed certificate, export it and remove it from the store to use for testing.
+            Don't use CurrentUser certificates for this test because they won't be found because
+            DSC LCM runs under a different context (Local System).
+        #>
+        $certificate = New-SelfSignedCertificate `
+            -DnsName $ENV:ComputerName `
+            -CertStoreLocation Cert:\LocalMachine\My
+        $certificatePath = Join-Path `
+            -Path $ENV:Temp `
+            -ChildPath "CertificateDsc.Common.Tests-$($certificate.Thumbprint).cer"
+        $null = Export-Certificate `
+            -Cert $certificate `
+            -Type CERT `
+            -FilePath $certificatePath
+        $null = Remove-Item `
+            -Path $certificate.PSPath `
+            -Force
+
+        Describe "$ModuleName\Import-CertificateEx" {
+            Context 'Import a valid x509 Certificate file into "CurrentUser\My" store' {
+                It 'Should not throw an exception' {
+                    { Import-CertificateEx -FilePath $certificatePath -CertStoreLocation 'Cert:\CurrentUser\My' } | Should -Not -Throw
+                }
+
+                It 'Should have imported the certificate with the correct values' {
+                    $importedCert = Get-ChildItem -Path ('Cert:\CurrentUser\My\{0}' -f $certificate.Thumbprint)
+                    $importedCert.Thumbprint | Should -Be $certificate.Thumbprint
+                    $importedCert.HasPrivateKey | Should -Be $false
+                }
+            }
+        }
+
+        # Remove the imported certificate
+        Remove-Item -Path ('Cert:\CurrentUser\My\{0}' -f $certificate.Thumbprint) -Force -ErrorAction SilentlyContinue
+
+        <#
+            Generate a self-signed certificate, export it and remove it from the store to use for testing.
+            Don't use CurrentUser certificates for this test because they won't be found because
+            DSC LCM runs under a different context (Local System).
+        #>
+        $certificate = New-SelfSignedCertificate `
+            -DnsName $ENV:ComputerName `
+            -CertStoreLocation Cert:\LocalMachine\My
+        $certificatePath = Join-Path `
+            -Path $ENV:Temp `
+            -ChildPath "CertificateDsc.Common.Tests-$($Certificate.Thumbprint).pfx"
+        $certificateExportPath = Join-Path `
+            -Path $ENV:Temp `
+            -ChildPath "CertificateDsc.Common.Tests.Export-$($Certificate.Thumbprint).pfx"
+        $testUsername = 'DummyUsername'
+        $testPassword = 'DummyPassword'
+        $testPasswordSecure = (ConvertTo-SecureString $testPassword -AsPlainText -Force)
+        $testCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @($testUsername, $testPasswordSecure)
+        $null = Export-PfxCertificate `
+            -Cert $certificate `
+            -FilePath $certificatePath `
+            -Password $testCredential.Password
+        $null = Remove-Item `
+            -Path $certificate.PSPath `
+            -Force
+
+        Describe "$ModuleName\Import-PfxCertificateEx" {
+            Context 'Import a valid PKCS12 PFX Certificate file into "CurrentUser\My" store with non-exportable key' {
+                It 'Should not throw an exception' {
+                    { Import-PfxCertificateEx -FilePath $certificatePath -CertStoreLocation 'Cert:\CurrentUser\My' -Password $testPasswordSecure } | Should -Not -Throw
+                }
+
+                It 'Should have imported the certificate with the correct values' {
+                    $importedCert = Get-ChildItem -Path ('Cert:\CurrentUser\My\{0}' -f $certificate.Thumbprint)
+                    $importedCert.Thumbprint | Should -Be $certificate.Thumbprint
+                    $importedCert.HasPrivateKey | Should -Be $true
+                }
+
+                It 'Should not be exportable' {
+                    $importedCert = Get-ChildItem -Path ('Cert:\CurrentUser\My\{0}' -f $certificate.Thumbprint)
+                    { $null = Export-PfxCertificate `
+                        -Cert $importedCert `
+                        -FilePath $certificateExportPath `
+                        -Password $testCredential.Password
+                    } | Should -Throw 'Cannot export non-exportable private key.'
+
+                    $null = Remove-Item `
+                        -Path $certificateExportPath `
+                        -Force `
+                        -ErrorAction SilentlyContinue
+                }
+
+                # Remove the imported certificate
+                Remove-Item -Path ('Cert:\CurrentUser\My\{0}' -f $certificate.Thumbprint) -Force -ErrorAction SilentlyContinue
+            }
+
+            Context 'Import a valid PKCS12 PFX Certificate file into "CurrentUser\My" store with exportable key' {
+                It 'Should not throw an exception' {
+                    { Import-PfxCertificateEx -FilePath $certificatePath -CertStoreLocation 'Cert:\CurrentUser\My' -Password $testPasswordSecure -Exportable } | Should -Not -Throw
+                }
+
+                It 'Should have imported the certificate with the correct values' {
+                    $importedCert = Get-ChildItem -Path ('Cert:\CurrentUser\My\{0}' -f $certificate.Thumbprint)
+                    $importedCert.Thumbprint | Should -Be $certificate.Thumbprint
+                    $importedCert.HasPrivateKey | Should -Be $true
+                }
+
+                It 'Should be exportable' {
+                    $importedCert = Get-ChildItem -Path ('Cert:\CurrentUser\My\{0}' -f $certificate.Thumbprint)
+                    { $null = Export-PfxCertificate `
+                        -Cert $importedCert `
+                        -FilePath $certificateExportPath `
+                        -Password $testCredential.Password
+                    } | Should -Not -Throw
+
+                    $null = Remove-Item `
+                        -Path $certificateExportPath `
+                        -Force `
+                        -ErrorAction SilentlyContinue
+                }
+
+                # Remove the imported certificate
+                Remove-Item -Path ('Cert:\CurrentUser\My\{0}' -f $certificate.Thumbprint) -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}
+finally
+{
+    #region FOOTER
+
+    #endregion
+}

--- a/Tests/Integration/CertificateDsc.Common.Tests.ps1
+++ b/Tests/Integration/CertificateDsc.Common.Tests.ps1
@@ -103,7 +103,7 @@ try
                     $importedCert.HasPrivateKey | Should -Be $true
                 }
 
-                It 'Should not be exportable' {
+                It 'Should not be exportable and should throw the expected exception message' {
                     $importedCert = Get-ChildItem -Path ('Cert:\CurrentUser\My\{0}' -f $certificate.Thumbprint)
                     { $null = Export-PfxCertificate `
                         -Cert $importedCert `

--- a/Tests/Unit/CertificateDsc.Common.Tests.ps1
+++ b/Tests/Unit/CertificateDsc.Common.Tests.ps1
@@ -4,9 +4,9 @@ $script:ModuleName = 'CertificateDsc.Common'
 # Unit Test Template Version: 1.1.0
 [String] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xCertificate'
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -74,7 +74,7 @@ try
             -----END CERTIFICATE-----
             "
 
-            $cerFileWithoutSan = "
+        $cerFileWithoutSan = "
             -----BEGIN CERTIFICATE-----
             MIIDBjCCAe6gAwIBAgIQRQyErZRGrolI5DfZCJDaTTANBgkqhkiG9w0BAQsFADAW
             MRQwEgYDVQQDDAtTb21lU2VydmVyMjAeFw0xNzA1MDkxNjI0MTZaFw0xODA1MDkx
@@ -96,11 +96,11 @@ try
             -----END CERTIFICATE-----
             "
 
-            $cerBytes = [System.Text.Encoding]::ASCII.GetBytes($cerFileWithSan)
-            $cerBytesWithoutSan = [System.Text.Encoding]::ASCII.GetBytes($cerFileWithoutSan)
+        $cerBytes = [System.Text.Encoding]::ASCII.GetBytes($cerFileWithSan)
+        $cerBytesWithoutSan = [System.Text.Encoding]::ASCII.GetBytes($cerFileWithoutSan)
 
-            $testCertificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($cerBytes)
-            $testCertificateWithoutSan = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($cerBytesWithoutSan)
+        $testCertificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($cerBytes)
+        $testCertificateWithoutSan = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($cerBytesWithoutSan)
 
         Describe "$DSCResourceName\Test-CertificatePath" {
             $null | Set-Content -Path $validPath
@@ -144,7 +144,7 @@ try
             }
 
             Context 'a single missing file by pipeline with -Quiet' {
-                $result =  $invalidPath | Test-CertificatePath -Quiet
+                $result = $invalidPath | Test-CertificatePath -Quiet
                 It 'Should return false' {
                     ($result -is [bool]) | Should -Be $true
                     $result | Should -Be $false
@@ -192,7 +192,7 @@ try
             }
 
             Context 'a single invalid thumbprint by pipeline with -Quiet' {
-                $result =  $invalidThumbprint | Test-Thumbprint -Quiet
+                $result = $invalidThumbprint | Test-Thumbprint -Quiet
                 It 'Should return false' {
                     ($result -is [bool]) | Should -Be $true
                     $result | Should -Be $false
@@ -208,11 +208,11 @@ try
             $certDNSNames = @('www.fabrikam.com', 'www.contoso.com')
             $certDNSNamesReverse = @('www.contoso.com', 'www.fabrikam.com')
             $certDNSNamesNoMatch = $certDNSNames + @('www.nothere.com')
-            $certKeyUsage = @('DigitalSignature','DataEncipherment')
-            $certKeyUsageReverse = @('DataEncipherment','DigitalSignature')
+            $certKeyUsage = @('DigitalSignature', 'DataEncipherment')
+            $certKeyUsageReverse = @('DataEncipherment', 'DigitalSignature')
             $certKeyUsageNoMatch = $certKeyUsage + @('KeyEncipherment')
-            $certEKU = @('Server Authentication','Client authentication')
-            $certEKUReverse = @('Client authentication','Server Authentication')
+            $certEKU = @('Server Authentication', 'Client authentication')
+            $certEKUReverse = @('Client authentication', 'Server Authentication')
             $certEKUNoMatch = $certEKU + @('Encrypting File System')
             $certSubject = 'CN=contoso, DC=com'
             $certFriendlyName = 'Contoso Test Cert'
@@ -656,22 +656,22 @@ try
                 Mock `
                     -CommandName Get-CdpContainer `
                     -MockWith {
-                        [CmdletBinding()]
-                        param
-                        (
-                            $DomainName
-                        )
-                        return New-Object -TypeName psobject -Property @{
-                            Children = @(
-                                @{
-                                    distinguishedName = 'CN=CA1,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
-                                    Children = @{
-                                        distinguishedName = 'CN=LabRootCA1,CN=CA1,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
-                                    }
+                    [CmdletBinding()]
+                    param
+                    (
+                        $DomainName
+                    )
+                    return New-Object -TypeName psobject -Property @{
+                        Children = @(
+                            @{
+                                distinguishedName = 'CN=CA1,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
+                                Children          = @{
+                                    distinguishedName = 'CN=LabRootCA1,CN=CA1,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
                                 }
-                            )
-                        }
+                            }
+                        )
                     }
+                }
 
                 Mock `
                     -CommandName Test-CertificateAuthority `
@@ -697,22 +697,22 @@ try
                 Mock `
                     -CommandName Get-CdpContainer `
                     -MockWith {
-                        [CmdletBinding()]
-                        param
-                        (
-                            $DomainName
-                        )
-                        return New-Object -TypeName psobject -Property @{
-                            Children = @(
-                                @{
-                                    distinguishedName = 'CN=CA1,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
-                                    Children = @{
-                                        distinguishedName = 'CN=LabRootCA1,CN=CA1,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
-                                    }
+                    [CmdletBinding()]
+                    param
+                    (
+                        $DomainName
+                    )
+                    return New-Object -TypeName psobject -Property @{
+                        Children = @(
+                            @{
+                                distinguishedName = 'CN=CA1,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
+                                Children          = @{
+                                    distinguishedName = 'CN=LabRootCA1,CN=CA1,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
                                 }
-                            )
-                        }
+                            }
+                        )
                     }
+                }
 
                 Mock `
                     -CommandName Test-CertificateAuthority `
@@ -736,14 +736,14 @@ try
                 Mock `
                     -CommandName Get-CdpContainer `
                     -MockWith {
-                        [CmdletBinding()]
-                        param
-                        (
-                            $DomainName
-                        )
-                        New-InvalidOperationException `
-                            -Message ($LocalizedData.DomainNotJoinedError)
-                    }
+                    [CmdletBinding()]
+                    param
+                    (
+                        $DomainName
+                    )
+                    New-InvalidOperationException `
+                        -Message ($LocalizedData.DomainNotJoinedError)
+                }
 
                 Mock `
                     -CommandName Test-CertificateAuthority `
@@ -769,42 +769,42 @@ try
                 -CommandName New-Object `
                 -ParameterFilter { $TypeName -eq 'System.Diagnostics.ProcessStartInfo' } `
                 -MockWith {
-                    $retObj = New-Object -TypeName psobject -Property @{
-                        FileName = ''
-                        Arguments = ''
-                        RedirectStandardError = $false
-                        RedirectStandardOutput = $true
-                        UseShellExecute = $false
-                        CreateNoWindow = $true
-                    }
-
-                    return $retObj
+                $retObj = New-Object -TypeName psobject -Property @{
+                    FileName               = ''
+                    Arguments              = ''
+                    RedirectStandardError  = $false
+                    RedirectStandardOutput = $true
+                    UseShellExecute        = $false
+                    CreateNoWindow         = $true
                 }
+
+                return $retObj
+            }
 
             Context 'Function is executed with CA online' {
                 Mock `
                     -CommandName New-Object `
                     -ParameterFilter { $TypeName -eq 'System.Diagnostics.Process' } `
                     -MockWith {
-                        $retObj = New-Object -TypeName psobject -Property @{
-                            StartInfo = $null
-                            ExitCode = 0
-                            StandardOutput = New-Object -TypeName psobject |
-                                Add-Member -MemberType ScriptMethod -Name ReadToEnd -Value {
-                                return @"
+                    $retObj = New-Object -TypeName psobject -Property @{
+                        StartInfo      = $null
+                        ExitCode       = 0
+                        StandardOutput = New-Object -TypeName psobject |
+                            Add-Member -MemberType ScriptMethod -Name ReadToEnd -Value {
+                            return @"
 Connecting to LabRootCA1\CA1 ...
 Server "CA1" ICertRequest2 interface is alive (32ms)
 CertUtil: -ping command completed successfully.
 "@
-                            } -PassThru
-                        }
-
-                        $retObj |
-                            Add-Member -MemberType ScriptMethod -Name Start -Value {} -PassThru |
-                            Add-Member -MemberType ScriptMethod -Name WaitForExit -Value {}
-
-                        return $retObj
+                        } -PassThru
                     }
+
+                    $retObj |
+                        Add-Member -MemberType ScriptMethod -Name Start -Value {} -PassThru |
+                        Add-Member -MemberType ScriptMethod -Name WaitForExit -Value {}
+
+                    return $retObj
+                }
 
                 It 'Should not throw' {
                     $script:result = Test-CertificateAuthority `
@@ -835,27 +835,27 @@ CertUtil: -ping command completed successfully.
                     -CommandName New-Object `
                     -ParameterFilter { $TypeName -eq 'System.Diagnostics.Process' } `
                     -MockWith {
-                        $retObj = New-Object -TypeName psobject -Property @{
-                            StartInfo = $null
-                            ExitCode = -2147024809
-                            StandardOutput = New-Object -TypeName psobject |
-                                Add-Member -MemberType ScriptMethod -Name ReadToEnd -Value {
-                                return @"
+                    $retObj = New-Object -TypeName psobject -Property @{
+                        StartInfo      = $null
+                        ExitCode       = -2147024809
+                        StandardOutput = New-Object -TypeName psobject |
+                            Add-Member -MemberType ScriptMethod -Name ReadToEnd -Value {
+                            return @"
 Connecting to LabRootCA1\CA2 ...
 Server could not be reached: The parameter is incorrect. 0x80070057 (WIN32: 87 ERROR_INVALID_PARAMETER) -- (31ms)
 
 CertUtil: -ping command FAILED: 0x80070057 (WIN32: 87 ERROR_INVALID_PARAMETER)
 CertUtil: The parameter is incorrect.
 "@
-                            } -PassThru
-                        }
-
-                        $retObj |
-                            Add-Member -MemberType ScriptMethod -Name Start -Value {} -PassThru |
-                            Add-Member -MemberType ScriptMethod -Name WaitForExit -Value {}
-
-                        return $retObj
+                        } -PassThru
                     }
+
+                    $retObj |
+                        Add-Member -MemberType ScriptMethod -Name Start -Value {} -PassThru |
+                        Add-Member -MemberType ScriptMethod -Name WaitForExit -Value {}
+
+                    return $retObj
+                }
 
                 It 'Should not throw' {
                     $script:result = Test-CertificateAuthority `
@@ -906,6 +906,49 @@ CertUtil: The parameter is incorrect.
             Context 'A certificate without SAN is used' {
                 It 'Should return null' {
                     Get-CertificateSan -Certificate $testCertificateWithoutSan | Should -BeNullOrEmpty
+                }
+            }
+        }
+        Describe 'Test-CommandExists' {
+            $testCommandName = 'TestCommandName'
+
+            Mock -CommandName 'Get-Command' -MockWith { return $Name }
+
+            Context 'Get-Command returns the command' {
+                It 'Should not throw' {
+                    { $null = Test-CommandExists -Name $testCommandName } | Should Not Throw
+                }
+
+                It 'Should retrieve the command with the specified name' {
+                    $getCommandParameterFilter = {
+                        return $Name -eq $testCommandName
+                    }
+
+                    Assert-MockCalled -CommandName 'Get-Command' -ParameterFilter $getCommandParameterFilter -Exactly 1 -Scope 'Context'
+                }
+
+                It 'Should return true' {
+                    Test-CommandExists -Name $testCommandName | Should Be $true
+                }
+            }
+
+            Context 'Get-Command returns null' {
+                Mock -CommandName 'Get-Command' -MockWith { return $null }
+
+                It 'Should not throw' {
+                    { $null = Test-CommandExists -Name $testCommandName } | Should Not Throw
+                }
+
+                It 'Should retrieve the command with the specified name' {
+                    $getCommandParameterFilter = {
+                        return $Name -eq $testCommandName
+                    }
+
+                    Assert-MockCalled -CommandName 'Get-Command' -ParameterFilter $getCommandParameterFilter -Exactly 1 -Scope 'Context'
+                }
+
+                It 'Should return false' {
+                    Test-CommandExists -Name $testCommandName | Should Be $false
                 }
             }
         }

--- a/Tests/Unit/CertificateDsc.Common.Tests.ps1
+++ b/Tests/Unit/CertificateDsc.Common.Tests.ps1
@@ -916,7 +916,7 @@ CertUtil: The parameter is incorrect.
 
             Context 'Get-Command returns the command' {
                 It 'Should not throw' {
-                    { $null = Test-CommandExists -Name $testCommandName } | Should Not Throw
+                    { $null = Test-CommandExists -Name $testCommandName } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the command with the specified name' {
@@ -928,7 +928,7 @@ CertUtil: The parameter is incorrect.
                 }
 
                 It 'Should return true' {
-                    Test-CommandExists -Name $testCommandName | Should Be $true
+                    Test-CommandExists -Name $testCommandName | Should -Be $true
                 }
             }
 
@@ -936,7 +936,7 @@ CertUtil: The parameter is incorrect.
                 Mock -CommandName 'Get-Command' -MockWith { return $null }
 
                 It 'Should not throw' {
-                    { $null = Test-CommandExists -Name $testCommandName } | Should Not Throw
+                    { $null = Test-CommandExists -Name $testCommandName } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the command with the specified name' {
@@ -948,7 +948,7 @@ CertUtil: The parameter is incorrect.
                 }
 
                 It 'Should return false' {
-                    Test-CommandExists -Name $testCommandName | Should Be $false
+                    Test-CommandExists -Name $testCommandName | Should -Be $false
                 }
             }
         }


### PR DESCRIPTION
**Pull Request (PR) description**
AAdded support for WS 2008R2 for xCertificateImport and xPfxImport by adding simple
`Import-CertificateEx` and `Import-PfxCertificateEx` cmdlets that get executed if the ones in PKI do
not exist.

**This Pull Request (PR) fixes the following issues:**
Fixes #46

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x]  New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

@Johlju - would you mind reviewing if you get a moment? No urgency!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcertificate/110)
<!-- Reviewable:end -->
