### PR TITLE
xCertReq - Allow certificate templates with spaces in them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- xCertReq:
+  - Fixed behaviour to allow certificate templates with spaces in the name
 - Added `Documentation and Examples` section to Readme.md file - see
   [issue #98](https://github.com/PowerShell/xCertificate/issues/98).
 - Changed description in Credential parameter of xPfxImport resource

--- a/Modules/xCertificate/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
+++ b/Modules/xCertificate/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
@@ -446,7 +446,7 @@ FriendlyName = "$FriendlyName"
     $requestDetails += @"
 
 [RequestAttributes]
-CertificateTemplate = `"$CertificateTemplate`"
+CertificateTemplate = "$CertificateTemplate"
 [EnhancedKeyUsageExtension]
 OID = $OID
 "@
@@ -455,7 +455,7 @@ OID = $OID
     {
         $requestDetails = $requestDetails.Replace(@"
 [RequestAttributes]
-CertificateTemplate = `"$CertificateTemplate`"
+CertificateTemplate = "$CertificateTemplate"
 [EnhancedKeyUsageExtension]
 "@, '[EnhancedKeyUsageExtension]')
     }
@@ -466,7 +466,7 @@ CertificateTemplate = `"$CertificateTemplate`"
         $requestDetails += @"
 
 [Extensions]
-2.5.29.17 = `"{text}$SubjectAltName`"
+2.5.29.17 = "{text}$SubjectAltName"
 "@
     }
     if ($thumbprint)

--- a/Modules/xCertificate/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
+++ b/Modules/xCertificate/DSCResources/MSFT_xCertReq/MSFT_xCertReq.psm1
@@ -446,7 +446,7 @@ FriendlyName = "$FriendlyName"
     $requestDetails += @"
 
 [RequestAttributes]
-CertificateTemplate = $CertificateTemplate
+CertificateTemplate = `"$CertificateTemplate`"
 [EnhancedKeyUsageExtension]
 OID = $OID
 "@
@@ -455,7 +455,7 @@ OID = $OID
     {
         $requestDetails = $requestDetails.Replace(@"
 [RequestAttributes]
-CertificateTemplate = $CertificateTemplate
+CertificateTemplate = `"$CertificateTemplate`"
 [EnhancedKeyUsageExtension]
 "@, '[EnhancedKeyUsageExtension]')
     }

--- a/Modules/xCertificate/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
+++ b/Modules/xCertificate/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
@@ -527,7 +527,7 @@ function Get-CertificateTemplateName
     {
         $temp = $Certificate.Extensions | Where-Object { $PSItem.Oid.Value -eq '1.3.6.1.4.1.311.21.7' }
         $null = $temp.Format(0) -match 'Template=(?<TemplateName>.*)\('
-        $templateName = $Matches.TemplateName -replace ' '
+        $templateName = $Matches.TemplateName
     }
 
     if ('1.3.6.1.4.1.311.20.2' -in $Certificate.Extensions.oid.Value)

--- a/Tests/Unit/MSFT_xCertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_xCertReq.Tests.ps1
@@ -332,14 +332,14 @@ RequestType = CMC
 KeyUsage = $keyUsage
 FriendlyName = "$friendlyName"
 [RequestAttributes]
-CertificateTemplate = `"$certificateTemplate`"
+CertificateTemplate = "$certificateTemplate"
 [EnhancedKeyUsageExtension]
 OID = $oid
 "@
 
         $certInfNoTemplate = $certInf.Replace(@"
 [RequestAttributes]
-CertificateTemplate = `"$certificateTemplate`"
+CertificateTemplate = "$certificateTemplate"
 [EnhancedKeyUsageExtension]
 "@, '[EnhancedKeyUsageExtension]')
 

--- a/Tests/Unit/MSFT_xCertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_xCertReq.Tests.ps1
@@ -332,14 +332,14 @@ RequestType = CMC
 KeyUsage = $keyUsage
 FriendlyName = "$friendlyName"
 [RequestAttributes]
-CertificateTemplate = $certificateTemplate
+CertificateTemplate = `"$certificateTemplate`"
 [EnhancedKeyUsageExtension]
 OID = $oid
 "@
 
         $certInfNoTemplate = $certInf.Replace(@"
 [RequestAttributes]
-CertificateTemplate = $certificateTemplate
+CertificateTemplate = `"$certificateTemplate`"
 [EnhancedKeyUsageExtension]
 "@, '[EnhancedKeyUsageExtension]')
 


### PR DESCRIPTION
Quote template name in certificate request
Fix Get-CertificateTemplateName to allow for spaces

**This Pull Request (PR) fixes the following issues:**
#111

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcertificate/112)
<!-- Reviewable:end -->
