### PR TITLE
Get-CertificateTemplateName: Fix missing template name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Get-CertificateTemplateName: Fix missing template name
+
 ## 3.1.0.0
 
 - xCertReq:

--- a/Modules/xCertificate/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
+++ b/Modules/xCertificate/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
@@ -543,7 +543,7 @@ function Get-CertificateTemplateName
                 $result = (dsquery.exe * "CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,$domain" -scope subtree -attr cn msPKI-Cert-Template-OID)
 
                 # Now extract the matching line from all results and the extract the template name itself
-                $null = ($result -match $tempateOid)[0] -match "[\s]*(?<TemplateName>.*)    $tempateOid"
+                $null = ($result -match $templateOid)[0] -match "[\s]*(?<TemplateName>.*)    $templateOid"
                 $templateName = ([String] $Matches.TemplateName).Trim()
             }
         }

--- a/Modules/xCertificate/Modules/CertificateDsc.Common/en-us/CertificateDsc.Common.strings.psd1
+++ b/Modules/xCertificate/Modules/CertificateDsc.Common/en-us/CertificateDsc.Common.strings.psd1
@@ -14,4 +14,5 @@ ConvertFrom-StringData @'
     CaFoundMessage                      = Found certificate authority '{0}\{1}'.
     CaOnlineMessage                     = Certificate authority '{0}\{1}' is online.
     CaOfflineMessage                    = Certificate authority '{0}\{1}' is offline.
+    TemplateNameResolutionError         = Failed to resolve the template name in Active Directory: {0}
 '@


### PR DESCRIPTION
**Pull Request (PR) description**
On my system, every time the DSC configuration runs xCertReq, a new certificate gets issued, because it can't match the template name. Fix: Query the template name from active directory if the template has no display name:
![certtemp](https://user-images.githubusercontent.com/1934246/35021004-024caa02-fb2f-11e7-80b7-5dcfdf3df084.png)

**This Pull Request (PR) fixes the following issues:**
No issue, direct PR.

**Task list:**
- [X] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcertificate/119)
<!-- Reviewable:end -->
