### PR TITLE
Updated Test-Thumbprint to handle non available hash algorithms

### DIFF
--- a/Modules/xCertificate/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
+++ b/Modules/xCertificate/Modules/CertificateDsc.Common/CertificateDSc.Common.psm1
@@ -124,15 +124,29 @@ function Test-Thumbprint
         $validHashes = @()
         foreach ($hashProvider in $hashProviders)
         {
-            $bitSize = ( New-Object -TypeName $hashProvider ).HashSize
-            $validHash = New-Object `
-                -TypeName PSObject `
-                -Property @{
-                Hash      = $hashProvider.BaseType.Name
-                BitSize   = $bitSize
-                HexLength = $bitSize / 4
+            try
+            {
+                $bitSize = ( New-Object -TypeName $hashProvider -ErrorAction Stop ).HashSize
+                $validHash = New-Object `
+                    -TypeName PSObject `
+                    -Property @{
+                    Hash      = $hashProvider.BaseType.Name
+                    BitSize   = $bitSize
+                    HexLength = $bitSize / 4
+                }
+                $validHashes += @( $validHash )
+                }
+            catch
+            {
+                if($PSItem.FullyQualifiedErrorId -eq 'ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand')
+                {
+                    Write-Warning -Message "$($hashProvider.Name) is not supported"
+                }
+                else
+                {
+                    throw $PSItem
+                }
             }
-            $validHashes += @( $validHash )
         }
     }
 


### PR DESCRIPTION
Adds a try catch around creating a hash provider object in Test-Thumbprint. This handles the case when FIPS compliant algorithms are enabled. Referenced in issue https://github.com/PowerShell/xCertificate/issues/122

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcertificate/123)
<!-- Reviewable:end -->
